### PR TITLE
Fixes certificate syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ build/
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
+# OS X Junk
+.DS_Store
 
 # Added by Felix
 /*.itmsp

--- a/lib/spaceship/certificate.rb
+++ b/lib/spaceship/certificate.rb
@@ -137,7 +137,6 @@ module Spaceship
     def download
       OpenSSL::X509::Certificate.new(download_raw)
     end
-    end
 
     def revoke!
       client.revoke_certificate!(id, type_display_id)


### PR DESCRIPTION
Fixes the certification file error I was experiencing in #25 by removing the extra `end` statement for the `download` method. Also adds `.DS_Store` to the `.gitignore`.
