### PR TITLE
Add the ability to manage multiple spaceships through Spaceship::Control

### DIFF
--- a/lib/spaceship.rb
+++ b/lib/spaceship.rb
@@ -14,13 +14,6 @@ module Spaceship
     attr_accessor :config, :client
 
     def login(username = nil, password = nil)
-      if !username or !password
-        require 'credentials_manager'
-        data = CredentialsManager::PasswordManager.shared_manager(username, false)
-        username ||= data.username
-        password ||= data.password
-      end
-
       @client = Client.login(username, password)
     end
   end

--- a/lib/spaceship.rb
+++ b/lib/spaceship.rb
@@ -24,9 +24,4 @@ module Spaceship
       @client = Client.login(username, password)
     end
   end
-
-  Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
-
-  # FastlaneCore::UpdateChecker.verify_latest_version('spaceship', Spaceship::VERSION)
-
 end

--- a/lib/spaceship.rb
+++ b/lib/spaceship.rb
@@ -1,5 +1,4 @@
 require 'spaceship/version'
-require 'fastlane_core'
 require 'spaceship/base'
 require 'spaceship/client'
 require 'spaceship/profile_types'
@@ -7,6 +6,7 @@ require 'spaceship/app'
 require 'spaceship/certificate'
 require 'spaceship/device'
 require 'spaceship/provisioning_profile'
+require 'spaceship/launcher'
 
 module Spaceship
   # Use this to just setup the configuration attribute and set it later somewhere else
@@ -29,32 +29,4 @@ module Spaceship
 
   # FastlaneCore::UpdateChecker.verify_latest_version('spaceship', Spaceship::VERSION)
 
-  class Control
-
-    attr_accessor :client
-
-    def initialize
-      @client = Client.new
-    end
-
-    ## helper methods for managing multiple instances of spaceship
-
-    ##
-    #
-    def app
-      Spaceship::App.set_client(@client)
-    end
-
-    def device
-      Spaceship::Device.set_client(@client)
-    end
-
-    def certificate
-      Spaceship::Certificate.set_client(@client)
-    end
-
-    def provisioning_profile
-      Spaceship::ProvisioningProfile.set_client(@client)
-    end
-  end
 end

--- a/lib/spaceship.rb
+++ b/lib/spaceship.rb
@@ -16,5 +16,27 @@ module Spaceship
     def login(username = nil, password = nil)
       @client = Client.login(username, password)
     end
+
+    # Helper methods for managing multiple instances of spaceship
+
+    # @return (Class) Access the apps for the spaceship
+    def app
+      Spaceship::App.set_client(@client)
+    end
+
+    # @return (Class) Access the devices for the spaceship
+    def device
+      Spaceship::Device.set_client(@client)
+    end
+
+    # @return (Class) Access the certificates for the spaceship
+    def certificate
+      Spaceship::Certificate.set_client(@client)
+    end
+
+    # @return (Class) Access the provisioning profiles for the spaceship
+    def provisioning_profile
+      Spaceship::ProvisioningProfile.set_client(@client)
+    end
   end
 end

--- a/lib/spaceship.rb
+++ b/lib/spaceship.rb
@@ -28,4 +28,33 @@ module Spaceship
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
 
   # FastlaneCore::UpdateChecker.verify_latest_version('spaceship', Spaceship::VERSION)
+
+  class Control
+
+    attr_accessor :client
+
+    def initialize
+      @client = Client.new
+    end
+
+    ## helper methods for managing multiple instances of spaceship
+
+    ##
+    #
+    def app
+      Spaceship::App.set_client(@client)
+    end
+
+    def device
+      Spaceship::Device.set_client(@client)
+    end
+
+    def certificate
+      Spaceship::Certificate.set_client(@client)
+    end
+
+    def provisioning_profile
+      Spaceship::ProvisioningProfile.set_client(@client)
+    end
+  end
 end

--- a/lib/spaceship/base.rb
+++ b/lib/spaceship/base.rb
@@ -32,9 +32,22 @@ module Spaceship
       end
 
       ##
-      # are we trying to get a subclass?
-      # if the method matches a underscored version
+      # Call a method to return a subclass constant.
+      #
+      # If `method_sym` is an underscored name of a class,
       # return the class with the current client passed into it.
+      # If the method does not match, NoMethodError is raised.
+      #
+      # Example:
+      #
+      #   Certificate.production_push
+      #   #=> Certificate::ProductionPush
+      #
+      #   ProvisioningProfile.ad_hoc
+      #   #=> ProvisioningProfile::AdHoc
+      #
+      #   ProvisioningProfile.some_other_method
+      #   #=> NoMethodError: undefined method `some_other_method' for ProvisioningProfile
       def method_missing(method_sym, *args, &block)
         module_name = method_sym.to_s
         module_name.sub!(/^[a-z\d]/) { $&.upcase }

--- a/lib/spaceship/base.rb
+++ b/lib/spaceship/base.rb
@@ -18,14 +18,14 @@ module Spaceship
       def remap_keys!(attrs)
         return if attr_mapping.nil?
 
-        @attr_mapping.each do |from, to|
+        attr_mapping.each do |from, to|
           attrs[to] = attrs.delete(from)
         end
       end
 
-      def attr_mapping(attrs = nil)
-        if attrs
-          @attr_mapping = attrs
+      def attr_mapping(attr_map = nil)
+        if attr_map
+          @attr_mapping = attr_map
         else
           @attr_mapping ||= ancestors[1].attr_mapping rescue nil
         end

--- a/lib/spaceship/certificate.rb
+++ b/lib/spaceship/certificate.rb
@@ -88,6 +88,7 @@ module Spaceship
         # Here we go
         klass = CERTIFICATE_TYPE_IDS[attrs['certificateTypeDisplayId']]
         klass ||= Certificate
+        klass.client = @client
         klass.new(attrs)
       end
 

--- a/lib/spaceship/certificate.rb
+++ b/lib/spaceship/certificate.rb
@@ -26,7 +26,7 @@ module Spaceship
     class DevelopmentPush < PushCertificate; end
     class ProductionPush < PushCertificate; end
     class WebsitePush < PushCertificate; end
-    class VoIPPush < PushCertificate; end
+    class VoipPush < PushCertificate; end
     class Passbook < Certificate; end
     class ApplePay < Certificate; end
 

--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -82,6 +82,13 @@ module Spaceship
     # returns Spaceship::Client
     def login(username = nil, password = nil)
       if username.to_s.empty? or password.to_s.empty?
+        require 'credentials_manager'
+        data = CredentialsManager::PasswordManager.shared_manager(username, false)
+        username ||= data.username
+        password ||= data.password
+      end
+
+      if username.to_s.empty? or password.to_s.empty?
         raise InvalidUserCredentialsError.new("No login data provided")
       end
 

--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -114,7 +114,7 @@ module Spaceship
       return @current_team_id if @current_team_id
 
       if teams.count > 1
-        Helper.log.warn "The current user is in #{teams.count} teams. Pass a team ID or call `select_team` to choose a team. Using the first one for now."
+        puts "The current user is in #{teams.count} teams. Pass a team ID or call `select_team` to choose a team. Using the first one for now."
       end
       @current_team_id ||= teams[0]['teamId']
     end

--- a/lib/spaceship/launcher.rb
+++ b/lib/spaceship/launcher.rb
@@ -2,33 +2,56 @@ module Spaceship
   class Launcher
     attr_accessor :client
 
-    def initialize
+    # Create a new spaceship client
+    # @param user (String) (optional): Username
+    # @param password (String) (optional): Password
+    def initialize(user = nil, password = nil)
       @client = Client.new
+      @client.login(user, password)
     end
 
     # Login Helper
+
+    # Login using username and password
+    # @param user (String): Username
+    # @param password (String): Password
     def login(user, password) 
       @client.login(user, password)
     end
 
+    # Open up the team selection for the user (if necessary).
+    # 
+    # If the user is in multiple teams, a team selection is shown.
+    # The user can then select a team by entering the number
+    # 
+    # Additionally, the team ID is shown next to each team name
+    # so that the user can use the environment variable `FASTLANE_TEAM_ID`
+    # for future user.
+    # 
+    # @return (String) The ID of the select team. You also get the value if 
+    #   the user is only in one team.
     def select_team
       @client.select_team
     end
 
-    ## helper methods for managing multiple instances of spaceship
+    # Helper methods for managing multiple instances of spaceship
 
+    # @return (Class) Access the apps for this spaceship
     def app
       Spaceship::App.set_client(@client)
     end
 
+    # @return (Class) Access the devices for this spaceship
     def device
       Spaceship::Device.set_client(@client)
     end
 
+    # @return (Class) Access the certificates for this spaceship
     def certificate
       Spaceship::Certificate.set_client(@client)
     end
 
+    # @return (Class) Access the provisioning profiles for this spaceship
     def provisioning_profile
       Spaceship::ProvisioningProfile.set_client(@client)
     end

--- a/lib/spaceship/launcher.rb
+++ b/lib/spaceship/launcher.rb
@@ -1,0 +1,36 @@
+module Spaceship
+  class Launcher
+    attr_accessor :client
+
+    def initialize
+      @client = Client.new
+    end
+
+    # Login Helper
+    def login(user, password) 
+      @client.login(user, password)
+    end
+
+    def select_team
+      @client.select_team
+    end
+
+    ## helper methods for managing multiple instances of spaceship
+
+    def app
+      Spaceship::App.set_client(@client)
+    end
+
+    def device
+      Spaceship::Device.set_client(@client)
+    end
+
+    def certificate
+      Spaceship::Certificate.set_client(@client)
+    end
+
+    def provisioning_profile
+      Spaceship::ProvisioningProfile.set_client(@client)
+    end
+  end
+end

--- a/lib/spaceship/provisioning_profile.rb
+++ b/lib/spaceship/provisioning_profile.rb
@@ -48,6 +48,7 @@ module Spaceship
         attrs['devices'].map! { |device| Device.factory(device) }
         attrs['certificates'].map! { |cert| Certificate.factory(cert) }
 
+        klass.client = @client
         klass.new(attrs)
       end
 

--- a/spaceship.gemspec
+++ b/spaceship.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # fastlane specific
-  spec.add_dependency 'fastlane_core', '>= 0.7.0' # all shared code and dependencies
   spec.add_dependency 'credentials_manager', '>= 0.5.0' # to automatically get login information
 
   # external

--- a/spec/device_spec.rb
+++ b/spec/device_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spaceship::Device do
   before { Spaceship.login }
-  let(:client) { Spaceship::Certificate.client }
+  let(:client) { Spaceship::Device.client }
 
   subject { Spaceship::Device.all }
   it "successfully loads and parses all devices" do

--- a/spec/provisioning_profile_spec.rb
+++ b/spec/provisioning_profile_spec.rb
@@ -4,6 +4,14 @@ describe Spaceship::ProvisioningProfile do
   before { Spaceship.login }
   let(:client) { Spaceship::ProvisioningProfile.client }
 
+  describe '.factory' do
+    it 'should instantiate a subclass and pass the client' do
+      propro = Spaceship::ProvisioningProfile.factory({'distributionMethod' => 'store', 'appId' => {}, 'devices' => [{}], 'certificates' => []})
+      expect(propro).to be_instance_of(Spaceship::ProvisioningProfile::AdHoc)
+      expect(propro.client).to eq(client)
+    end
+  end
+
   describe '#all' do
     let(:provisioning_profiles) { Spaceship::ProvisioningProfile.all }
 

--- a/spec/spaceship_base_spec.rb
+++ b/spec/spaceship_base_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Spaceship::Base do
+  let(:client) { double('Client') }
+  before { Spaceship.client = double('Default Client') }
+
+  describe 'Class Methods' do
+    it 'will use a default client' do
+      expect(Spaceship::Base.client).to eq(Spaceship.client)
+    end
+
+    it 'can set a client' do
+      Spaceship::Base.client = client
+      expect(Spaceship::Base.client).to eq(client)
+    end
+
+    it 'can set a client and return itself' do
+      expect(Spaceship::Base.set_client(client)).to eq(Spaceship::Base)
+    end
+
+    describe 'instantiation from an attribute hash' do
+      let(:test_class) do
+        Class.new(Spaceship::Base) do
+          attr_accessor :some_attr_name
+          attr_mapping({
+            'someAttributeName' => :some_attr_name
+          })
+        end
+      end
+
+      it 'can create an attribute mapping' do
+        inst = test_class.new('someAttributeName' => 'some value')
+        expect(inst.some_attr_name).to eq('some value')
+      end
+
+      it 'can inherit the attribute mapping' do
+        subclass = Class.new(test_class)
+        inst = subclass.new('someAttributeName' => 'some value')
+        expect(inst.some_attr_name).to eq('some value')
+      end
+    end
+
+    it 'can constantize subclasses by calling a method on the parent class' do
+      class Developer < Spaceship::Base
+        class RubyDeveloper < Developer
+        end
+      end
+
+      expect(Developer.ruby_developer).to eq(Developer::RubyDeveloper)
+    end
+  end
+end

--- a/spec/spaceship_spec.rb
+++ b/spec/spaceship_spec.rb
@@ -6,4 +6,20 @@ describe Spaceship do
   it 'should initialize with a client' do
     expect(Spaceship.client).to be_instance_of(Spaceship::Client)
   end
+
+  describe Spaceship::Control do
+    it 'has a client' do
+      expect(subject.client).to be_instance_of(Spaceship::Client)
+    end
+
+    it 'returns a scoped model class' do
+      expect(subject.app).to eq(Spaceship::App)
+      expect(subject.certificate).to eq(Spaceship::Certificate)
+      expect(subject.device).to eq(Spaceship::Device)
+      expect(subject.provisioning_profile).to eq(Spaceship::ProvisioningProfile)
+    end
+    it 'passes the client to the models' do
+      expect(subject.device.client).to eq(subject.client)
+    end
+  end
 end

--- a/spec/spaceship_spec.rb
+++ b/spec/spaceship_spec.rb
@@ -7,7 +7,7 @@ describe Spaceship do
     expect(Spaceship.client).to be_instance_of(Spaceship::Client)
   end
 
-  describe Spaceship::Control do
+  describe Spaceship::Launcher do
     it 'has a client' do
       expect(subject.client).to be_instance_of(Spaceship::Client)
     end


### PR DESCRIPTION
Here is the attempt at managing multiple spaceship by the introduction of the `Spaceship::Control` class.

Example:

``` ruby
spaceship1 = Spaceship::Control.new
spaceship2 = Spaceship::Control.new

spaceship1.client.login #this method could be aliased to spaceship1, so it looks like: spaceship1.login
spaceship2.client.login

spaceship1.certificate
#=> Spaceship::Certificate
spaceship1.certificate.production_push
#=> Spaceship::Certificate::ProductionPush
spaceship1.certificate.production_push.all
#=> [#<Spaceship::Certificate::ProductionPush>, #<Spaceship::Certificate::ProductionPush> ... ]

spaceship2.device
#=> Spaceship::Device
spaceship2.device.all
#=> [#<Spaceship::Device 1>, #<Spaceship::Device 2> ... ]
```

I have not been able to really thoroughly test this because I only have 1 dev account, but I was able to set the team on 1 client, and set the team on another client and then test it for correctness like this:

``` ruby
spaceship1.client.select_team #choose 1
spaceship2.client.select_team #choose 2
```

Any feedback or comments are welcome
