### PR TITLE
Updated ApiKey extractor method

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -79,7 +79,7 @@ module Spaceship
         agent.user_agent_alias = 'Mac Safari'
       }
       a.get(landing_url) do |page|
-        login_page = a.click(page.link_with(text: /Member Center/))
+        login_page = a.click(page.link_with(href: /membercenter/))
         api_key = login_page.forms.first['appIdKey']
         File.write(cache_path, api_key)
         return api_key

--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -1,4 +1,5 @@
 require 'faraday' # HTTP Client
+require 'mechanize' # Interaction with website 
 require 'logger'
 require 'faraday_middleware'
 require 'spaceship/ui'
@@ -71,11 +72,15 @@ module Spaceship
       cached = File.read(cache_path) rescue nil
       return cached if cached
 
-      landing_url = "https://developer.apple.com/devcenter/ios/index.action"
+      landing_url = "https://developer.apple.com/ios/"
       logger.info("GET: " + landing_url)
-      page = @client.get(landing_url).body
-      if page =~ %r{<a href="https://idmsa.apple.com/IDMSWebAuth/login\?.*appIdKey=(\h+)}
-        api_key = $1
+
+      a = Mechanize.new { |agent|
+        agent.user_agent_alias = 'Mac Safari'
+      }
+      a.get(landing_url) do |page|
+        login_page = a.click(page.link_with(text: /Member Center/))
+        api_key = login_page.forms.first['appIdKey']
         File.write(cache_path, api_key)
         return api_key
       end

--- a/spaceship.gemspec
+++ b/spaceship.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '~> 3.1'
   spec.add_dependency 'faraday', '~> 0.8.9' # 0.8.9 because of shenzhen :(
   spec.add_dependency 'faraday_middleware', '~> 0.9'
+  spec.add_dependency 'mechanize' # Interaction with website 
 
   # Development only
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
After WWDC keynote, Apple has changed the developers portal, so the method to get the api key stopped working.

I created a new method using `Mechanize` (http://mechanize.rubyforge.org/index.html) because we need to interact with the portal to get the new api key.
