### PR TITLE
Updated faraday to 0.9.1

### DIFF
--- a/spaceship.gemspec
+++ b/spaceship.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # external
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'plist', '~> 3.1'
-  spec.add_dependency 'faraday', '~> 0.8.9' # 0.8.9 because of shenzhen :(
+  spec.add_dependency 'faraday', '~> 0.9' # finally the latest version  :)
   spec.add_dependency 'faraday_middleware', '~> 0.9'
 
   # Development only


### PR DESCRIPTION
Update of faraday to 0.9.1 should be stable, test-suite runs fine, and other gem dependencies (shenzen, etc...) have been tested as well.
