### PR TITLE
Include teamId param in Client#download_certificate

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -334,6 +334,7 @@ module Spaceship
       {type: type, certificate_id: certificate_id}.each { |k, v| raise "#{k} must not be nil" if v.nil? }
 
       r = request(:post, 'https://developer.apple.com/account/ios/certificate/certificateContentDownload.action', {
+        teamId: team_id,
         displayId: certificate_id,
         type: type
       })

--- a/spec/spaceship_stubbing.rb
+++ b/spec/spaceship_stubbing.rb
@@ -122,7 +122,7 @@ def stub_certificates
     to_return(status: 200, body: read_fixture_file( "list_certificates_filtered.json"), headers: {'Content-Type' => 'application/json'})
 
   stub_request(:post, "https://developer.apple.com/account/ios/certificate/certificateContentDownload.action").
-    with(body: {"displayId"=>"XC5PH8DAAA", "type"=>"R58UK2EAAA"},
+    with(body: {"displayId"=>"XC5PH8DAAA", "type"=>"R58UK2EAAA", "teamId" => "XXXXXXXXXX"},
          headers: {'Cookie'=>'myacinfo=abcdef;'}).
     to_return(status: 200, body: read_fixture_file('aps_development.cer'))
   stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/ios/certificate/submitCertificateRequest.action").
@@ -162,7 +162,7 @@ RSpec.configure do |config|
   config.before(:each) do
 
     stub_request(:get, "https://developer.apple.com/membercenter/index.action").
-      to_return(status: 200, body: nil, 
+      to_return(status: 200, body: nil,
         headers: {'Location' => "https://idmsa.apple.com/IDMSWebAuth/login?&appIdKey=0123abcdef123123&path=%2F%2Fmembercenter%2Findex.action"}
       )
 


### PR DESCRIPTION
Without teamId, accounts with multiple teams get a 302 response to the selectTeam.action page instead of the certificate data.
