### PR TITLE
Replaced 'rescue nil' with more precise error handling.

### DIFF
--- a/lib/spaceship/base.rb
+++ b/lib/spaceship/base.rb
@@ -71,7 +71,10 @@ module Spaceship
         if attr_map
           @attr_mapping = attr_map
         else
-          @attr_mapping ||= ancestors[1].attr_mapping rescue nil
+          begin
+            @attr_mapping ||= ancestors[1].attr_mapping 
+          rescue NameError, NoMethodError
+          end
         end
       end
 

--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -68,7 +68,10 @@ module Spaceship
     # Fetches the latest API Key from the Apple Dev Portal
     def api_key
       cache_path = "/tmp/spaceship_api_key.txt"
-      cached = File.read(cache_path) rescue nil
+      begin
+        cached = File.read(cache_path) 
+      rescue Errno::ENOENT
+      end
       return cached if cached
 
       landing_url = "https://developer.apple.com/membercenter/index.action"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,15 @@ end
 cache_path = "/tmp/spaceship_api_key.txt"
 RSpec.configure do |config|
   config.before(:each) do
-    File.delete(cache_path) rescue nil
+    begin
+      File.delete(cache_path) 
+    rescue Errno::ENOENT
+    end
   end
   config.after(:each) do
-    File.delete(cache_path) rescue nil # to not break the actual spaceship
+    begin
+      File.delete(cache_path)  # to not break the actual spaceship
+    rescue Errno::ENOENT
+    end
   end
 end


### PR DESCRIPTION
Using 'rescue nil' although brief is too vague for safe error handling.
Instead it may be better to be precise in which errors we want to recover from. 
