### PR TITLE
introduce DataHash that can lookup nested properties in a Hash.

### DIFF
--- a/lib/spaceship/base.rb
+++ b/lib/spaceship/base.rb
@@ -64,6 +64,7 @@ module Spaceship
 
       ##
       # Binds attributes getters and setters to underlying data returned from the API.
+      # Setting any properties will alter the `raw_data` hash.
       #
       # @return (Hash) the attribute mapping used by `remap_keys!`
       def data_bind!(data)
@@ -74,7 +75,7 @@ module Spaceship
           setter_method = "#{dest}=".to_sym
 
           unless public_method_defined?(getter_method)
-            raise NoMethodError.new("Cannot define attribute mapping for missing attribute `#{attribute}`")
+            raise NoMethodError.new("Cannot define attribute mapping for missing attribute `#{getter_method}`")
           end
 
           define_method(getter_method) do
@@ -82,7 +83,7 @@ module Spaceship
           end
 
           unless public_method_defined?(setter_method)
-            raise NoMethodError.new("Cannot define attribute mapping for missing attribute `#{attribute}`")
+            raise NoMethodError.new("Cannot define attribute mapping for missing attribute `#{setter_method}`")
           end
 
           define_method(setter_method) do |value|

--- a/lib/spaceship/tunes/app_version.rb
+++ b/lib/spaceship/tunes/app_version.rb
@@ -95,26 +95,26 @@ module Spaceship
 
 
       attr_mapping({
-        'versionId' => :version_id,
-        'copyright' => :copyright,
-        'primaryCategory' => :primary_category,
-        'primaryFirstSubCategory' => :primary_first_sub_category,
-        'primarySecondSubCategory' => :primary_second_sub_category,
-        'secondaryCategory' => :secondary_category,
-        'secondaryFirstSubCategory' => :secondary_first_sub_category,
-        'secondarySecondSubCategory' => :secondary_second_sub_category,
-        'status' => :status,
-        'canRejectVersion' => :can_reject_version,
-        'canPrepareForUpload' => :can_prepare_for_upload,
-        'canSendVersionLive' => :can_send_version_live,
-        'details' => :languages,
-        'largeAppIcon.value.url' => :app_icon_url,
-        'largeAppIcon.value.originalFileName' => :app_icon_original_name,
-        'watchAppIcon.value.url' => :watch_app_icon_url,
-        'watchAppIcon.value.originalFileName' => :watch_app_icon_original_name,
         'canBetaTest' => :can_beta_test,
-        'releaseOnApproval' => :release_on_approval,
-        'supportsAppleWatch' => :supports_apple_watch
+        'canPrepareForUpload' => :can_prepare_for_upload,
+        'canRejectVersion' => :can_reject_version,
+        'canSendVersionLive' => :can_send_version_live,
+        'copyright.value' => :copyright,
+        'details.value' => :languages,
+        'largeAppIcon.value.originalFileName' => :app_icon_original_name,
+        'largeAppIcon.value.url' => :app_icon_url,
+        'primaryCategory.value' => :primary_category,
+        'primaryFirstSubCategory.value' => :primary_first_sub_category,
+        'primarySecondSubCategory.value' => :primary_second_sub_category,
+        'releaseOnApproval.value' => :release_on_approval,
+        'secondaryCategory.value' => :secondary_category,
+        'secondaryFirstSubCategory.value' => :secondary_first_sub_category,
+        'secondarySecondSubCategory.value' => :secondary_second_sub_category,
+        'status' => :status,
+        'supportsAppleWatch' => :supports_apple_watch,
+        'versionId' => :version_id,
+        'watchAppIcon.value.originalFileName' => :watch_app_icon_original_name,
+        'watchAppIcon.value.url' => :watch_app_icon_url
       })
 
       class << self
@@ -146,11 +146,11 @@ module Spaceship
       # Prefill name, keywords, etc...
       def unfold_languages
         {
-          name: :name, 
-          keywords: :keywords, 
-          description: :description, 
-          privacyURL: :privacy_url, 
-          supportURL: :support_url, 
+          name: :name,
+          keywords: :keywords,
+          description: :description,
+          privacyURL: :privacy_url,
+          supportURL: :support_url,
           marketingURL: :marketing_url
         }.each do |json, attribute|
           instance_variable_set("@#{attribute}".to_sym, LanguageItem.new(json, languages))
@@ -175,4 +175,4 @@ module Spaceship
       end
     end
   end
-end 
+end

--- a/lib/spaceship/tunes/tunes_base.rb
+++ b/lib/spaceship/tunes/tunes_base.rb
@@ -1,42 +1,9 @@
 module Spaceship
   module Tunes
     class TunesBase < Spaceship::Base
-      attr_accessor :raw_data
-
       class << self
         def client
           @client || Spaceship::Tunes.client
-        end
-
-        def remap_keys!(attrs)
-          return if attr_mapping.nil?
-
-          attr_mapping.each do |from, to|
-            if attrs[from].is_a?(Hash)
-              attrs[to] = attrs.delete(from).fetch('value')
-            else
-              attrs[to] = attrs.delete(from) 
-            end
-          end
-        end
-
-        # Overwrite this, to also update the original values (raw_value), when sending back the changes to Apple
-        def attr_mapping(attr_map = nil)
-          result = super
-
-          (attr_map || []).each do |key,val|
-            define_method("#{key}=") do |value|
-              # Set the new value in any case
-              instance_variable_set("@#{key}".to_sym, value)
-
-              if raw_data
-                raw_data[key] ||= {}
-                raw_data[key]['value'] = value
-              end
-            end
-          end
-
-          return result
         end
       end
     end

--- a/spec/spaceship_base_spec.rb
+++ b/spec/spaceship_base_spec.rb
@@ -22,8 +22,10 @@ describe Spaceship::Base do
       let(:test_class) do
         Class.new(Spaceship::PortalBase) do
           attr_accessor :some_attr_name
+          attr_accessor :nested_attr_name
           attr_mapping({
-            'someAttributeName' => :some_attr_name
+            'someAttributeName' => :some_attr_name,
+            'nestedAttribute.name.value' => :nested_attr_name
           })
         end
       end
@@ -37,6 +39,11 @@ describe Spaceship::Base do
         subclass = Class.new(test_class)
         inst = subclass.new('someAttributeName' => 'some value')
         expect(inst.some_attr_name).to eq('some value')
+      end
+
+      it 'can map nested attributes' do
+        inst = test_class.new({'nestedAttribute' => {'name' => {'value' => 'a value'}}})
+        expect(inst.nested_attr_name).to eq('a value')
       end
     end
 


### PR DESCRIPTION
The PR simplifies the attribute accessors and mapping.

`raw_data` is now stored as a `DataHash` instance which has methods for looking up and setting dot-notated key paths.

Also removed that non-explicit "value" mapping of attributes such as this:

``` json
{"name": {"value": "Stefan"}}
```

now, the source mapping has to be done explicitly like:

``` ruby
attr_mapping({'name.value' => :name})
```
