### PR TITLE
BugFix: add waitingForReview status mapping to AppStatus.get_from_string method

### DIFF
--- a/lib/spaceship/tunes/app_status.rb
+++ b/lib/spaceship/tunes/app_status.rb
@@ -48,7 +48,8 @@ module Spaceship
           'prepareForUpload' => PREPARE_FOR_SUBMISSION,
           'devRejected' => DEVELOPER_REJECTED,
           'pendingContract' => PENDING_CONTRACT,
-          'developerRemovedFromSale' => DEVELOPER_REMOVED_FROM_SALE
+          'developerRemovedFromSale' => DEVELOPER_REMOVED_FROM_SALE,
+          'waitingForReview' => WAITING_FOR_REVIEW
         }
 
         mapping.each do |k, v| 


### PR DESCRIPTION
The waitingForReview (Waiting For Review) status is currently not mapped. this commit fixes this.
