### PR TITLE
Expose device class (eg. iPhone)  and model (eg. iPhone 4 GSM)

### DIFF
--- a/lib/spaceship/portal/device.rb
+++ b/lib/spaceship/portal/device.rb
@@ -32,14 +32,14 @@ module Spaceship
       #   'iPhone 6', 'iPhone 4 GSM'
       attr_accessor :model
 
-      # @return (String) Device class
+      # @return (String) Device type
       # @example
       #   'pc'     - Apple TV
       #   'watch'  - Apple Watch
       #   'ipad'   - iPad
       #   'iphone' - iPhone
       #   'ipod'   - iPod
-      attr_accessor :device_class
+      attr_accessor :device_type
 
       attr_mapping({
         'deviceId' => :id,
@@ -47,7 +47,7 @@ module Spaceship
         'deviceNumber' => :udid,
         'devicePlatform' => :platform,
         'status' => :status,
-        'deviceClass' => :device_class,
+        'deviceClass' => :device_type,
         'model' => :model
       })
 

--- a/lib/spaceship/portal/device.rb
+++ b/lib/spaceship/portal/device.rb
@@ -27,12 +27,28 @@ module Spaceship
       #   "c"
       attr_accessor :status
 
+      # @return (String) Model (can be nil)
+      # @example
+      #   'iPhone 6', 'iPhone 4 GSM'
+      attr_accessor :model
+
+      # @return (String) Device class
+      # @example
+      #   'pc'     - Apple TV
+      #   'watch'  - Apple Watch
+      #   'ipad'   - iPad
+      #   'iphone' - iPhone
+      #   'ipod'   - iPod
+      attr_accessor :device_class
+
       attr_mapping({
         'deviceId' => :id,
         'name' => :name,
         'deviceNumber' => :udid,
         'devicePlatform' => :platform,
-        'status' => :status
+        'status' => :status,
+        'deviceClass' => :device_class,
+        'model' => :model
       })
 
       class << self
@@ -45,6 +61,31 @@ module Spaceship
         # @return (Array) Returns all devices registered for this account
         def all
           client.devices.map { |device| self.factory(device) }
+        end
+
+        # @return (Array) Returns all Apple TVs registered for this account
+        def all_apple_tvs
+          client.devices_by_class('pc').map { |device| self.factory(device) }
+        end
+
+        # @return (Array) Returns all Watches registered for this account
+        def all_watches
+          client.devices_by_class('watch').map { |device| self.factory(device) }
+        end
+
+        # @return (Array) Returns all iPads registered for this account
+        def all_ipads
+          client.devices_by_class('ipad').map { |device| self.factory(device) }
+        end
+
+        # @return (Array) Returns all iPhones registered for this account
+        def all_iphones
+          client.devices_by_class('iphone').map { |device| self.factory(device) }
+        end
+
+        # @return (Array) Returns all iPods registered for this account
+        def all_ipod_touches
+          client.devices_by_class('ipod').map { |device| self.factory(device) }
         end
 
         # @return (Device) Find a device based on the ID of the device. *Attention*:

--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -165,6 +165,19 @@ module Spaceship
       end
     end
 
+    def devices_by_class(deviceClass)
+      paging do |page_number|
+        r = request(:post, 'account/ios/device/listDevices.action', {
+          teamId: team_id,
+          pageNumber: page_number,
+          pageSize: page_size,
+          sort: 'name=asc',
+          deviceClasses: deviceClass
+        })
+        parse_response(r, 'devices')
+      end
+    end
+
     def create_device!(device_name, device_id)
       req = request(:post) do |r|
         r.url "https://developerservices2.apple.com/services/#{PROTOCOL_VERSION}/ios/addDevice.action"

--- a/spec/portal/device_spec.rb
+++ b/spec/portal/device_spec.rb
@@ -4,15 +4,43 @@ describe Spaceship::Device do
   before { Spaceship.login }
   let(:client) { Spaceship::Device.client }
 
-  subject { Spaceship::Device.all }
+  subject(:all_devices) { Spaceship::Device.all }
   it "successfully loads and parses all devices" do
-    expect(subject.count).to eq(4)
-    device = subject.first
+    expect(all_devices.count).to eq(4)
+    device = all_devices.first
     expect(device.id).to eq('AAAAAAAAAA')
     expect(device.name).to eq('Felix\'s iPhone')
     expect(device.udid).to eq('a03b816861e89fac0a4da5884cb9d2f01bd5641e')
     expect(device.platform).to eq('ios')
     expect(device.status).to eq('c')
+    expect(device.model).to eq('iPhone 5 (Model A1428)')
+    expect(device.device_class).to eq('iphone')
+  end
+
+  subject(:all_phones) { Spaceship::Device.all_iphones }
+  it "successfully loads and parses all iPhones" do
+    expect(all_phones.count).to eq(3)
+    device = all_phones.first
+    expect(device.id).to eq('AAAAAAAAAA')
+    expect(device.name).to eq('Felix\'s iPhone')
+    expect(device.udid).to eq('a03b816861e89fac0a4da5884cb9d2f01bd5641e')
+    expect(device.platform).to eq('ios')
+    expect(device.status).to eq('c')
+    expect(device.model).to eq('iPhone 5 (Model A1428)')
+    expect(device.device_class).to eq('iphone')
+  end
+
+  subject(:all_ipods) { Spaceship::Device.all_ipod_touches }
+  it "successfully loads and parses all iPods" do
+    expect(all_ipods.count).to eq(1)
+    device = all_ipods.first
+    expect(device.id).to eq('CCCCCCCCCC')
+    expect(device.name).to eq('Personal iPhone')
+    expect(device.udid).to eq('97467684eb8dfa3c6d272eac3890dab0d001c706')
+    expect(device.platform).to eq('ios')
+    expect(device.status).to eq('c')
+    expect(device.model).to eq(nil)
+    expect(device.device_class).to eq('ipod')
   end
 
   it "inspect works" do

--- a/spec/portal/device_spec.rb
+++ b/spec/portal/device_spec.rb
@@ -14,7 +14,7 @@ describe Spaceship::Device do
     expect(device.platform).to eq('ios')
     expect(device.status).to eq('c')
     expect(device.model).to eq('iPhone 5 (Model A1428)')
-    expect(device.device_class).to eq('iphone')
+    expect(device.device_type).to eq('iphone')
   end
 
   subject(:all_phones) { Spaceship::Device.all_iphones }
@@ -27,7 +27,7 @@ describe Spaceship::Device do
     expect(device.platform).to eq('ios')
     expect(device.status).to eq('c')
     expect(device.model).to eq('iPhone 5 (Model A1428)')
-    expect(device.device_class).to eq('iphone')
+    expect(device.device_type).to eq('iphone')
   end
 
   subject(:all_ipods) { Spaceship::Device.all_ipod_touches }
@@ -40,7 +40,7 @@ describe Spaceship::Device do
     expect(device.platform).to eq('ios')
     expect(device.status).to eq('c')
     expect(device.model).to eq(nil)
-    expect(device.device_class).to eq('ipod')
+    expect(device.device_type).to eq('ipod')
   end
 
   it "inspect works" do

--- a/spec/portal/fixtures/listDevicesiPhone.action.json
+++ b/spec/portal/fixtures/listDevicesiPhone.action.json
@@ -11,7 +11,7 @@
   "isAgent": false,
   "pageNumber": 1,
   "pageSize": 100,
-  "totalRecords": 4,
+  "totalRecords": 3,
   "devices": [
     {
       "deviceId": "AAAAAAAAAA",
@@ -30,15 +30,6 @@
       "status": "c",
       "model": "iPhone 6",
       "deviceClass": "iphone"
-    },
-    {
-      "deviceId": "CCCCCCCCCC",
-      "name": "Personal iPhone",
-      "deviceNumber": "97467684eb8dfa3c6d272eac3890dab0d001c706",
-      "devicePlatform": "ios",
-      "status": "c",
-      "model": null,
-      "deviceClass": "ipod"
     },
     {
       "deviceId": "DDDDDDDDDD",

--- a/spec/portal/fixtures/listDevicesiPod.action.json
+++ b/spec/portal/fixtures/listDevicesiPod.action.json
@@ -1,0 +1,26 @@
+{
+  "creationTimestamp": "2015-04-25T00:02:42Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "protocolVersion": "QH65B2",
+  "requestId": null,
+  "requestUrl": "https://developer.apple.com:443/services-account/QH65B2/account/ios/device/listDevices.action",
+  "responseId": "21bcfffa-90cb-4e2b-8143-a20dca8a60b5",
+  "isAdmin": true,
+  "isMember": false,
+  "isAgent": false,
+  "pageNumber": 1,
+  "pageSize": 100,
+  "totalRecords": 1,
+  "devices": [
+    {
+      "deviceId": "CCCCCCCCCC",
+      "name": "Personal iPhone",
+      "deviceNumber": "97467684eb8dfa3c6d272eac3890dab0d001c706",
+      "devicePlatform": "ios",
+      "status": "c",
+      "model": null,
+      "deviceClass": "ipod"
+    }
+  ]
+}

--- a/spec/portal/portal_client_spec.rb
+++ b/spec/portal/portal_client_spec.rb
@@ -160,7 +160,7 @@ describe Spaceship::Client do
       let(:devices) { subject.devices }
       it 'returns a list of device hashes' do
         expect(devices).to be_instance_of(Array)
-        expect(devices.first.keys).to eq(["deviceId", "name", "deviceNumber", "devicePlatform", "status"])
+        expect(devices.first.keys).to eq(["deviceId", "name", "deviceNumber", "devicePlatform", "status", "model", "deviceClass"])
       end
     end
 

--- a/spec/portal/portal_stubbing.rb
+++ b/spec/portal/portal_stubbing.rb
@@ -94,6 +94,14 @@ end
 
 def adp_stub_devices
   stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/device/listDevices.action').
+    with(body: {deviceClasses: 'iphone', teamId: 'XXXXXXXXXX', pageSize: "500", pageNumber: "1", sort: 'name=asc'}, headers: {'Cookie' => 'myacinfo=abcdef;'}).
+    to_return(status: 200, body: adp_read_fixture_file('listDevicesiPhone.action.json'), headers: {'Content-Type' => 'application/json'})
+
+  stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/device/listDevices.action').
+    with(body: {deviceClasses: 'ipod', teamId: 'XXXXXXXXXX', pageSize: "500", pageNumber: "1", sort: 'name=asc'}, headers: {'Cookie' => 'myacinfo=abcdef;'}).
+    to_return(status: 200, body: adp_read_fixture_file('listDevicesiPod.action.json'), headers: {'Content-Type' => 'application/json'})
+
+  stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/ios/device/listDevices.action').
     with(body: {teamId: 'XXXXXXXXXX', pageSize: "500", pageNumber: "1", sort: 'name=asc'}, headers: {'Cookie' => 'myacinfo=abcdef;'}).
     to_return(status: 200, body: adp_read_fixture_file('listDevices.action.json'), headers: {'Content-Type' => 'application/json'})
 


### PR DESCRIPTION
- add device class / model to the device
- and allow retrieving devices filtered by device class (eg. iPad)
