### PR TITLE
Allow multiple certs to be specified in a provisioning profile

### DIFF
--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -278,7 +278,7 @@ module Spaceship
         provisioningProfileName: name,
         appIdId: app_id,
         distributionType: distribution_method,
-        certificateIds: certificate_ids.first, # we are most of the times only allowed to pass one
+        certificateIds: certificate_ids.join(','),
         deviceIds: device_ids
       })
 


### PR DESCRIPTION
I hit the situation where I was trying to update a provisioning profile (that contained multiple certificates) to include all of the devices in the team.

Running `update!` would cause all but the first cert to be dropped. 

I'm not sure if the comment about 'only allowed to pass one' is still relevant, but passing in all of the certificates works fine for me.
