### PR TITLE
toying around with SSL cipher detection

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -8,8 +8,11 @@ require 'spaceship/helper/net_http_generic_request'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 
+require 'openssl'
+OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ciphers] = '!ADH:!RC4:!aNULL:!MD5:!EXPORT:!SSLv2:HIGH'
+OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'TLSv1_2'
+
 if ENV["DEBUG"]
-  require 'openssl'
   # this has to be on top of this file, since the value can't be changed later
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -97,7 +97,7 @@ describe Spaceship::Client do
     end
   end
 
-  describe "SSL ciphers" do
+  describe "SSL ciphers", run_on_ci: false do
     class SSLValidatorClient < Spaceship::Client
       def self.hostname
         "https://www.howsmyssl.com"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-
 describe Spaceship::Client do
   class TestClient < Spaceship::Client
     def self.hostname
@@ -95,6 +94,30 @@ describe Spaceship::Client do
 
         expect(subject.req_home.body).to eq(default_body)
       end
+    end
+  end
+
+  describe "SSL ciphers" do
+    class SSLValidatorClient < Spaceship::Client
+      def self.hostname
+        "https://www.howsmyssl.com"
+      end
+    end
+
+    let(:client) { SSLValidatorClient.new }
+    before { WebMock.allow_net_connect! }
+    after { WebMock.disable_net_connect! }
+
+    it 'doesn\'t use weak ciphers when secured' do
+      json = client.send('request', :get, 'a/check').body
+      # Bad ?
+      expect(json['insecure_cipher_suites']).to eq({})
+      # improvable ?
+      expect(json['tls_version']).to eq('TLS 1.2')
+      expect(json['ephemeral_keys_supported']).to eq(true)
+      expect(json['session_ticket_supported']).to eq(true)
+      # Probably Okay
+      expect(json['rating']).to eq('Probably Okay')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,18 @@ def try_delete(path)
   FileUtils.rm_f path if File.exist? path
 end
 
+# still missing the fastlane_core dependency
+class Helper
+  # @return [boolean] true if building in a known CI environment
+  def self.ci?
+    # Check for Jenkins, Travis CI, ... environment variables
+    ['JENKINS_URL', 'TRAVIS', 'CIRCLECI', 'CI', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI'].each do |current|
+      return true if ENV.key?(current)
+    end
+    return false
+  end
+end
+
 RSpec.configure do |config|
   config.before(:each) do
     cache_paths.each { |path| try_delete path }
@@ -51,4 +63,6 @@ RSpec.configure do |config|
   config.after(:each) do
     cache_paths.each { |path| try_delete path }
   end
+
+  config.filter_run_excluding run_on_ci: !Helper.ci?
 end


### PR DESCRIPTION
By default some of spaceship uses weak SSL ciphers. This removes them.

The current pull request allows to conditionally enable the feature as to be able to test it on a wide range of use cases.

The tests use a third party service to validate the functionality.

Originally related to issue #54
