### PR TITLE
typo in provisioning_profile.rb

### DIFF
--- a/lib/spaceship/portal/provisioning_profile.rb
+++ b/lib/spaceship/portal/provisioning_profile.rb
@@ -208,7 +208,7 @@ module Spaceship
           certificate_parameter ||= [certificate.id]
 
           # Fix https://github.com/KrauseFx/fastlane/issues/349
-          certificate_parameter = certificate_parameter.first if certificate_parameter.count == 1
+          certificate_parameter = certificate_parameter.first if certificate_parameter.count != 1
 
           if devices.nil? or devices.count == 0
             if self == Development or self == AdHoc


### PR DESCRIPTION
should check if certificate_parameter size != 1, otherwise certificate_parameter still return an array
