### PR TITLE
Spaceship::Launcher.provisioning_profile raises exception

### DIFF
--- a/lib/spaceship/launcher.rb
+++ b/lib/spaceship/launcher.rb
@@ -88,6 +88,9 @@ module Spaceship
 
     # @return (Class) Access the provisioning profiles for this spaceship
     def provisioning_profile
+      app
+      device
+      certificate
       Spaceship::ProvisioningProfile.set_client(@client)
     end
   end

--- a/spec/launcher_spec.rb
+++ b/spec/launcher_spec.rb
@@ -43,5 +43,20 @@ describe Spaceship do
     it "App" do
       expect(spaceship1.app.all.count).to eq(5)
     end
+
+    context "With an uninitialized environment" do
+      before do
+        Spaceship::App.set_client(nil)
+        Spaceship::AppGroup.set_client(nil)
+        Spaceship::Device.set_client(nil)
+        Spaceship::Certificate.set_client(nil)
+        Spaceship::ProvisioningProfile.set_client(nil)
+      end
+      it "shouldn't fail if provisioning_profile is invoked before app and device" do
+        clean_launcher = Spaceship::Launcher.new
+        clean_launcher.login(username, password)
+        expect(clean_launcher.provisioning_profile.all.count).to eq(33)
+      end
+    end
   end
 end


### PR DESCRIPTION
Spacheship::Launcher needs to initialize other portal base classes before initializing ProvisioningProfile since that class eager loads the app, devices, and certificates.

This is easy to reproduce if you simply call `Spaceship::Launcher.new().provisioning_profile.all`.  The existing test suite passes because of the use of class variables to store the client, although `spec/launcher_spec.rb` will fail when run alone.

I added a test that clears out the client class variables and it fails reliably regardless of the rspec seed. 

This probably contains other bugs (e.g. if you attempt to authenticate with two completely different sets of credentials at the same time it probably fails).  If you think it would be helpful to refactor the launcher to remove or override the class variable, I'd be willing to help.  For now, this patch fixes our use case.

Great gem -- we really appreciate all the hard work. 
