### PR TITLE
Update build train with testing status

### DIFF
--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -79,6 +79,13 @@ module Spaceship
         data['trains'].each do |train|
           train["#{testing_type}Testing"]['value'] = false
           train["#{testing_type}Testing"]['value'] = new_value if train['versionString'] == version_string
+
+          #also update the builds
+          train['builds'].each do |build|
+            next if build["#{testing_type}Testing"].nil?
+            build["#{testing_type}Testing"]['value'] = false
+            build["#{testing_type}Testing"]['value'] = new_value if build['trainVersion'] == version_string
+          end
         end
 
         result = client.update_build_trains!(application.apple_id, testing_type, data)

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -74,7 +74,7 @@ module Spaceship
 
       # @return (Spaceship::Tunes::Build) The latest build for this train, sorted by upload time.
       def latest_build
-        @builds.max_by {|build| build.upload_date }
+        @builds.max_by(&:upload_date)
       end
 
       # @param (testing_type) internal or external

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -72,17 +72,20 @@ module Spaceship
         end
       end
 
+      #TODO: override internal_testing, external_testing setters and getters
+
       # @param (testing_type) internal or external
-      def update_testing_status!(new_value, testing_type)
+      def update_testing_status!(new_value, testing_type, build)
         data = client.build_trains(self.application.apple_id, testing_type)
 
         data['trains'].each do |train|
           train["#{testing_type}Testing"]['value'] = false
           train["#{testing_type}Testing"]['value'] = new_value if train['versionString'] == version_string
 
-          #also update the builds
+          # also update the builds
           train['builds'].each do |build|
             next if build["#{testing_type}Testing"].nil?
+            next if build["buildVersion"] != build.build_version
             build["#{testing_type}Testing"]['value'] = false
             build["#{testing_type}Testing"]['value'] = new_value if build['trainVersion'] == version_string
           end

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -74,20 +74,29 @@ module Spaceship
 
       #TODO: override internal_testing, external_testing setters and getters
 
+      # @return (Spaceship::Tunes::Build) The latest build for this train, sorted by upload time.
+      def latest_build
+        @builds.max_by do |build|
+          build.train_version == version_string && build.upload_date
+        end
+      end
+
       # @param (testing_type) internal or external
-      def update_testing_status!(new_value, testing_type, build)
+      def update_testing_status!(new_value, testing_type, build = nil)
         data = client.build_trains(self.application.apple_id, testing_type)
+
+        build ||= latest_build if testing_type == 'external'
 
         data['trains'].each do |train|
           train["#{testing_type}Testing"]['value'] = false
           train["#{testing_type}Testing"]['value'] = new_value if train['versionString'] == version_string
 
           # also update the builds
-          train['builds'].each do |build|
-            next if build["#{testing_type}Testing"].nil?
-            next if build["buildVersion"] != build.build_version
-            build["#{testing_type}Testing"]['value'] = false
-            build["#{testing_type}Testing"]['value'] = new_value if build['trainVersion'] == version_string
+          train['builds'].each do |b|
+            next if b["#{testing_type}Testing"].nil?
+            next if b["buildVersion"] != build.build_version
+            b["#{testing_type}Testing"]['value'] = false
+            b["#{testing_type}Testing"]['value'] = new_value if b['trainVersion'] == version_string
           end
         end
 

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -94,6 +94,7 @@ module Spaceship
           # also update the builds
           train['builds'].each do |b|
             next if b["#{testing_type}Testing"].nil?
+            next if build.nil?
             next if b["buildVersion"] != build.build_version
             b["#{testing_type}Testing"]['value'] = false
             b["#{testing_type}Testing"]['value'] = new_value if b['trainVersion'] == version_string

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -72,8 +72,6 @@ module Spaceship
         end
       end
 
-      #TODO: override internal_testing, external_testing setters and getters
-
       # @return (Spaceship::Tunes::Build) The latest build for this train, sorted by upload time.
       def latest_build
         @builds.max_by do |build|

--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -74,9 +74,7 @@ module Spaceship
 
       # @return (Spaceship::Tunes::Build) The latest build for this train, sorted by upload time.
       def latest_build
-        @builds.max_by do |build|
-          build.train_version == version_string && build.upload_date
-        end
+        @builds.max_by {|build| build.upload_date }
       end
 
       # @param (testing_type) internal or external


### PR DESCRIPTION
This PR updates the individual build testing status for external tests. iTunesConnect requires you to specify which build version you want to test for external testing.

addresses #155
