### PR TITLE
Fail early if ADC fails to return a provisioning profile

### DIFF
--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -287,10 +287,10 @@ module Spaceship
         type: type
       })
       a = parse_response(r)
-      if a.include?("Apple Inc")
+      if r.success? && a.include?("Apple Inc")
         return a
       else
-        raise "Couldn't download provisioning profile, got this instead: #{a}"
+        raise UnexpectedResponse.new, "Couldn't download provisioning profile, got this instead: #{a}"
       end
     end
 

--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -338,10 +338,10 @@ module Spaceship
         displayId: profile_id
       })
       a = parse_response(r)
-      if a.include?("DOCTYPE plist PUBLIC")
+      if r.success? && a.include?("DOCTYPE plist PUBLIC")
         return a
       else
-        raise "Couldn't download provisioning profile, got this instead: #{a}"
+        raise UnexpectedResponse.new, "Couldn't download provisioning profile, got this instead: #{a}"
       end
     end
 

--- a/spec/portal/certificate_spec.rb
+++ b/spec/portal/certificate_spec.rb
@@ -66,6 +66,15 @@ describe Spaceship::Certificate do
       x509 = OpenSSL::X509::Certificate.new(cert.download)
       expect(x509.issuer.to_s).to match('Apple Worldwide Developer Relations')
     end
+
+    it "handles failed download request" do
+      adp_stub_download_certificate_failure
+
+      error_text = /^Couldn't download provisioning profile, got this instead:/
+      expect do
+        cert.download
+      end.to raise_error(Spaceship::Client::UnexpectedResponse, error_text)
+    end
   end
 
   describe '#revoke' do

--- a/spec/portal/fixtures/download_certificate_failure.html
+++ b/spec/portal/fixtures/download_certificate_failure.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en-us">
+<head>
+  <title>Try your request again.</title>
+</head>
+<body id="error">
+  <h4>We are unable to process your request.</h4>
+  <p>An unknown error occurred. Please <a href="index.action">try again</a>.
+  <footer>
+    <p>Copyright &copy; 2015 Apple Inc. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/spec/portal/portal_stubbing.rb
+++ b/spec/portal/portal_stubbing.rb
@@ -206,6 +206,13 @@ def adp_stub_app_groups
     to_return(status: 200, body: adp_read_fixture_file('deleteApplicationGroup.action.json'), headers: { 'Content-Type' => 'application/json' })
 end
 
+def adp_stub_download_certificate_failure
+  stub_request(:post, 'https://developer.apple.com/account/ios/certificate/certificateContentDownload.action').
+    with(body: { "displayId" => "XC5PH8DAAA", "type" => "R58UK2EAAA", "teamId" => "XXXXXXXXXX" },
+         headers: { 'Cookie' => 'myacinfo=abcdef;' }).
+    to_return(status: 404, body: adp_read_fixture_file('download_certificate_failure.html'))
+end
+
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|

--- a/spec/portal/portal_stubbing.rb
+++ b/spec/portal/portal_stubbing.rb
@@ -213,6 +213,12 @@ def adp_stub_download_certificate_failure
     to_return(status: 404, body: adp_read_fixture_file('download_certificate_failure.html'))
 end
 
+def adp_stub_download_provisioning_profile_failure
+  stub_request(:get, "https://developer.apple.com/account/ios/profile/profileContentDownload.action?displayId=2MAY7NPHRU&teamId=XXXXXXXXXX").
+    with(headers: { 'Cookie' => 'myacinfo=abcdef;' }).
+    to_return(status: 404, body: adp_read_fixture_file('download_certificate_failure.html'))
+end
+
 WebMock.disable_net_connect!
 
 RSpec.configure do |config|

--- a/spec/provisioning_profile_spec.rb
+++ b/spec/provisioning_profile_spec.rb
@@ -90,6 +90,16 @@ describe Spaceship::ProvisioningProfile do
       expect(xml['AppIDName']).to eq("SunApp Setup")
       expect(xml['TeamName']).to eq("SunApps GmbH")
     end
+
+    it "handles failed download request" do
+      adp_stub_download_provisioning_profile_failure
+      profile = Spaceship::ProvisioningProfile.all.first
+
+      error_text = /^Couldn't download provisioning profile, got this instead:/
+      expect do
+        profile.download
+      end.to raise_error(Spaceship::Client::UnexpectedResponse, error_text)
+    end
   end
 
   describe '#valid?' do


### PR DESCRIPTION
This is just the first step to tackling fastlane/sigh#141 but will
need some exception catching over there so it doesn't block
parsing/downloading of the other certificates.
