### PR TITLE
Fixed wrong error message when failing to download a certificate

### DIFF
--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -292,7 +292,7 @@ module Spaceship
       if r.success? && a.include?("Apple Inc")
         return a
       else
-        raise UnexpectedResponse.new, "Couldn't download provisioning profile, got this instead: #{a}"
+        raise UnexpectedResponse.new, "Couldn't download certificate, got this instead: #{a}"
       end
     end
 

--- a/spec/portal/certificate_spec.rb
+++ b/spec/portal/certificate_spec.rb
@@ -70,7 +70,7 @@ describe Spaceship::Certificate do
     it "handles failed download request" do
       adp_stub_download_certificate_failure
 
-      error_text = /^Couldn't download provisioning profile, got this instead:/
+      error_text = /^Couldn't download certificate, got this instead:/
       expect do
         cert.download
       end.to raise_error(Spaceship::Client::UnexpectedResponse, error_text)


### PR DESCRIPTION
Guess I could have been more alert when I touched that code last week... 
