### PR TITLE
Expose the cookie so that session data can be shared.

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -64,11 +64,12 @@ module Spaceship
     end
 
     def initialize
+      @cookie = HTTP::CookieJar.new
       @client = Faraday.new(self.class.hostname) do |c|
         c.response :json, content_type: /\bjson$/
         c.response :xml, content_type: /\bxml$/
         c.response :plist, content_type: /\bplist$/
-        c.use :cookie_jar
+        c.use :cookie_jar, jar: @cookie
         c.adapter Faraday.default_adapter
 
         if ENV['DEBUG']
@@ -98,6 +99,14 @@ module Spaceship
       end
 
       @logger
+    end
+
+    ##
+    # Return the session cookie.
+    #
+    # @return (String) the cookie-string in the RFC6265 format: https://tools.ietf.org/html/rfc6265#section-4.2.1
+    def cookie
+      @cookie.map(&:to_s).join(';')
     end
 
     #####################################################

--- a/spec/tunes/tunes_client_spec.rb
+++ b/spec/tunes/tunes_client_spec.rb
@@ -11,8 +11,11 @@ describe Spaceship::TunesClient do
 
   describe 'client' do
     it 'exposes the session cookie' do
-      subject.login('bad-username', 'bad-password') rescue nil
-      expect(subject.cookie).to eq('session=invalid')
+      begin
+        subject.login('bad-username', 'bad-password')
+      rescue Spaceship::Client::InvalidUserCredentialsError
+        expect(subject.cookie).to eq('session=invalid')
+      end
     end
   end
 

--- a/spec/tunes/tunes_client_spec.rb
+++ b/spec/tunes/tunes_client_spec.rb
@@ -9,6 +9,13 @@ describe Spaceship::TunesClient do
     end
   end
 
+  describe 'client' do
+    it 'exposes the session cookie' do
+      subject.login('bad-username', 'bad-password') rescue nil
+      expect(subject.cookie).to eq('session=invalid')
+    end
+  end
+
   describe "Logged in" do
     subject { Spaceship::Tunes.client }
     let(:username) { 'spaceship@krausefx.com' }

--- a/spec/tunes/tunes_stubbing.rb
+++ b/spec/tunes/tunes_stubbing.rb
@@ -22,7 +22,7 @@ def itc_stub_login
   # Failed login attempts
   stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=1234567890").
     with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
-    to_return(status: 401, body: '{}', headers: {'Set-Cookie' => 'session=invalid'})
+    to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
 end
 
 def itc_stub_applications

--- a/spec/tunes/tunes_stubbing.rb
+++ b/spec/tunes/tunes_stubbing.rb
@@ -22,7 +22,7 @@ def itc_stub_login
   # Failed login attempts
   stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=1234567890").
     with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
-    to_return(status: 401, body: '{}')
+    to_return(status: 401, body: '{}', headers: {'Set-Cookie' => 'session=invalid'})
 end
 
 def itc_stub_applications


### PR DESCRIPTION
Fixes backwards-compatibility breaking changes in previous release.

Used here: https://github.com/neonichu/xcode-install/issues/104
