### PR TITLE
Properly safeguard against a nil response body when parsing a response

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -247,12 +247,10 @@ module Spaceship
     end
 
     def parse_response(response, expected_key = nil)
-      content = if response.body
+      if response.body
         # If we have an `expected_key`, select that from response.body Hash
         # Else, don't.
-        expected_key ? response.body[expected_key] : response.body
-      else
-        nil
+        content = expected_key ? response.body[expected_key] : response.body
       end
 
       if content.nil?

--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -247,10 +247,12 @@ module Spaceship
     end
 
     def parse_response(response, expected_key = nil)
-      if expected_key
-        content = response.body[expected_key]
+      content = if response.body
+        # If we have an `expected_key`, select that from response.body Hash
+        # Else, don't.
+        expected_key ? response.body[expected_key] : response.body
       else
-        content = response.body
+        nil
       end
 
       if content.nil?


### PR DESCRIPTION
`Spaceship::Client#parse_response` attempted to safeguard against a nil `response.body` but it was not properly implemented.

If `response.body[expected_key]` turned out to be nil, we were safe. However, if `response.body` _itself_ was nil, we would get an error when trying to access `response.body[expected_key]`. This change safeguards against that.

_In response to [this](https://github.com/fastlane/spaceship/issues/189) issue._
