### PR TITLE
Support for tvOS versions:

### DIFF
--- a/lib/spaceship/tunes/app_version.rb
+++ b/lib/spaceship/tunes/app_version.rb
@@ -8,6 +8,9 @@ module Spaceship
       #   this version is for
       attr_accessor :application
 
+      # @return (String) The platform value of this version.
+      attr_accessor :platform
+
       # @return (String) The version number of this version
       attr_accessor :version
 
@@ -114,6 +117,7 @@ module Spaceship
 
       attr_mapping({
         'appType' => :app_type,
+        'platform' => :platform,
         'canBetaTest' => :can_beta_test,
         'canPrepareForUpload' => :can_prepare_for_upload,
         'canRejectVersion' => :can_reject_version,

--- a/lib/spaceship/tunes/tunes_client.rb
+++ b/lib/spaceship/tunes/tunes_client.rb
@@ -314,10 +314,16 @@ module Spaceship
 
       # We only support platforms that exist ATM
       platform = platforms.find do |p|
-        ['ios', 'osx'].include? p['platformString']
+        ['ios', 'osx', 'appletvos'].include? p['platformString']
       end
 
-      raise "Could not find platform ios or osx for app #{app_id}" unless platform
+      raise "Could not find platform ios, osx or appletvos for app #{app_id}" unless platform
+
+      # If your app has versions for both iOS and tvOS we will default to returning the iOS version for now.
+      # This is intentional as we need to do more work to support apps that have hybrid versions.
+      if platforms.length > 1
+        platform = platforms.detect { |p| p['platformString'] == "ios" }
+      end
 
       version = platform[(is_live ? 'deliverableVersion' : 'inFlightVersion')]
       return nil unless version

--- a/spec/tunes/app_version_spec.rb
+++ b/spec/tunes/app_version_spec.rb
@@ -31,6 +31,7 @@ describe Spaceship::AppVersion, all: true do
       expect(version.watch_app_icon.url).to eq('https://is1-ssl.mzstatic.com/image/thumb//0x0ss.jpg')
       expect(version.watch_app_icon.original_file_name).to eq('OriginalName.png')
       expect(version.transit_app_file).to eq(nil)
+      expect(version.platform).to eq("ios")
     end
 
     it "parses the localized values correctly" do

--- a/spec/tunes/fixtures/app_overview.json
+++ b/spec/tunes/fixtures/app_overview.json
@@ -51,9 +51,30 @@
         "supportedHardware": ["iphone"],
         "issuesCount": 0
       }
+    },{
+      "type": "APP",
+      "platformString": "appletvos",
+      "inFlightVersion": {
+        "type": "APP",
+        "id": "814995239",
+        "version": "1.0",
+        "state": "prepareForUpload",
+        "stateKey": "prepareForUpload",
+        "stateGroup": "preRelease",
+        "largeAppIcon": {
+          "assetToken": null,
+          "sortOrder": null,
+          "url": null,
+          "thumbNailUrl": null,
+          "originalFileName": null
+        },
+        "supportedHardware": ["iphone"],
+        "issuesCount": 0
+      },
+      "deliverableVersion": null
     }],
-    "allowedNewVersionPlatforms": ["appletvos"],
-    "submittablePlatforms": ["ios", "osx"],
+    "allowedNewVersionPlatforms": [],
+    "submittablePlatforms": ["ios", "osx", "appletvos"],
     "appStoreUrl": "https://itunes.apple.com/us/app/why-new-itc-2/id1039164429?ls=1&mt=8",
     "analyticsUrl": null,
     "salesAndTrendsUrl": null,


### PR DESCRIPTION
- Versions of tvOS apps are now fetched correctly.
- If your app has mixed platform types in the returned versions
  we default to the iOS version to preserve backwards compatibility.
  Addressing multi platform versions is a much bigger change.
- Updated specs.
