### PR TITLE
Remove dependency of native extensions.

### DIFF
--- a/lib/spaceship/helper/cookie_jar_middleware.rb
+++ b/lib/spaceship/helper/cookie_jar_middleware.rb
@@ -1,0 +1,34 @@
+require 'cookiejar'
+
+module Faraday
+  class CookieJar < Faraday::Middleware
+    def initialize(app, options = {})
+      super(app)
+      @jar = options[:jar] || CookieJar::Jar.new
+    end
+
+    def call(env)
+      cookies = @jar.get_cookies(env[:url])
+
+      unless cookies.empty?
+        if env[:request_headers]["Cookie"]
+          env[:request_headers]["Cookie"] = @jar.get_cookie_header(env[:url]) + ";" + env[:request_headers]["Cookie"]
+        else
+          env[:request_headers]["Cookie"] = @jar.get_cookie_header(env[:url])
+        end
+      end
+
+      @app.call(env).on_complete do |res|
+        if res[:response_headers]
+          @jar.set_cookies_from_headers(env[:url], res[:response_headers])
+        end
+      end
+    end
+  end
+end
+
+if Faraday.respond_to?(:register_middleware)
+  Faraday.register_middleware cookie_jar: -> { Faraday::CookieJar }
+elsif Faraday::Middleware.respond_to?(:register_middleware)
+  Faraday::Middleware.register_middleware cookie_jar: Faraday::CookieJar
+end

--- a/spaceship.gemspec
+++ b/spaceship.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '~> 3.1'
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.9'
-  spec.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   spec.add_dependency 'fastimage', '~> 1.6'
+  spec.add_dependency 'cookiejar', '~> 0.3'
 
   # for the playground
   spec.add_dependency 'pry'

--- a/spec/tunes/tunes_stubbing.rb
+++ b/spec/tunes/tunes_stubbing.rb
@@ -22,7 +22,7 @@ def itc_stub_login
   # Failed login attempts
   stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=1234567890").
     with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
-    to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
+    to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid; path=/; domain=apple.com' })
 end
 
 def itc_stub_applications


### PR DESCRIPTION
This PR attempts to remove the dependency of `unf` and `unf_ext` which introduce native extensions into `spaceship`

Problems: 
* https://github.com/fastlane/fastlane/issues/1047
* https://github.com/neonichu/xcode-install/issues/108

Proposed Solution:
By vendoring the `domain_name` gem, we can remove the `unf` dependency. In my opinion this is a low-impact change because we will most likely never deal with a non-ascii domain name in spaceship. For users using Ruby => 2.2.0, the behavior does not change since it is able to normalize unicode strings without an extension.

The problem is the added maintenance overhead of maintaining a vendored gem. Also, I am not 100% convinced this is the best way to distribute the patched `domain_name` gem, but it seems like the least-worst scenario.