### PR TITLE
make messages more clear about where multiple teams are found

### DIFF
--- a/lib/spaceship/portal/ui/select_team.rb
+++ b/lib/spaceship/portal/ui/select_team.rb
@@ -62,7 +62,7 @@ module Spaceship
         # User Selection
         loop do
           # Multiple teams, user has to select
-          puts "Multiple teams found, please enter the number of the team you want to use: "
+          puts "Multiple teams found on the Developer Portal, please enter the number of the team you want to use: "
           teams.each_with_index do |team, i|
             puts "#{i + 1}) #{team['teamId']} \"#{team['name']}\" (#{team['type']})"
           end

--- a/lib/spaceship/tunes/tunes_client.rb
+++ b/lib/spaceship/tunes/tunes_client.rb
@@ -90,7 +90,7 @@ module Spaceship
 
       # user didn't specify a team... #thisiswhywecanthavenicethings
       loop do
-        puts "Multiple teams found, please enter the number of the team you want to use: "
+        puts "Multiple iTunes Connect teams found, please enter the number of the team you want to use: "
         teams.each_with_index do |team, i|
           puts "#{i + 1}) \"#{team['contentProvider']['name']}\" (#{team['contentProvider']['contentProviderId']})"
         end


### PR DESCRIPTION
```
[13:47:58]: Verifying if app is available on the Apple Developer Portal and iTunes Connect...
[13:47:58]: Starting login with user 'ohayon@me.com'
Multiple teams found, please enter the number of the team you want to use: 
1) YVK2GRT6A2 "SunApps GmbH" (In-House)
2) V4QMA97S69 "David Ohayon" (Individual)
2
Multiple teams found, please enter the number of the team you want to use: 
1) "Felix Krause" (117954211)
2) "David Ohayon" (103020806)
2
```

This was the output while trying to run manual `init` because there are multiple teams on both iTC and the Dev Center. just making it a bit more clear.
