### PR TITLE
Update URLs for beta submitting

### DIFF
--- a/lib/spaceship/tunes/tunes_client.rb
+++ b/lib/spaceship/tunes/tunes_client.rb
@@ -528,7 +528,7 @@ module Spaceship
 
     def remove_testflight_build_from_review!(app_id: nil, train: nil, build_number: nil)
       r = request(:post) do |req|
-        req.url "ra/apps/#{app_id}/trains/#{train}/builds/#{build_number}/reject"
+        req.url "ra/apps/#{app_id}/platforms/ios/trains/#{train}/builds/#{build_number}/reject"
         req.body = {}.to_json
         req.headers['Content-Type'] = 'application/json'
       end
@@ -606,7 +606,7 @@ module Spaceship
       build_info['testInfo']['reviewPassword']['value'] = review_password
 
       r = request(:post) do |req| # same URL, but a POST request
-        req.url "ra/apps/#{app_id}/trains/#{train}/builds/#{build_number}/submit/start"
+        req.url "ra/apps/#{app_id}/platforms/ios/trains/#{train}/builds/#{build_number}/submit/start"
 
         req.body = build_info.to_json
         req.headers['Content-Type'] = 'application/json'
@@ -623,7 +623,7 @@ module Spaceship
 
     def get_build_info_for_review(app_id: nil, train: nil, build_number: nil)
       r = request(:get) do |req|
-        req.url "ra/apps/#{app_id}/trains/#{train}/builds/#{build_number}/submit/start"
+        req.url "ra/apps/#{app_id}/platforms/ios/trains/#{train}/builds/#{build_number}/submit/start"
         req.headers['Content-Type'] = 'application/json'
       end
       handle_itc_response(r.body)
@@ -640,7 +640,7 @@ module Spaceship
       encryption_info['encryptionUpdated']['value'] = encryption
 
       r = request(:post) do |req|
-        req.url "ra/apps/#{app_id}/trains/#{train}/builds/#{build_number}/submit/complete"
+        req.url "ra/apps/#{app_id}/platforms/ios/trains/#{train}/builds/#{build_number}/submit/complete"
         req.body = encryption_info.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/spec/tunes/tunes_stubbing.rb
+++ b/spec/tunes/tunes_stubbing.rb
@@ -147,15 +147,15 @@ end
 
 def itc_stub_testflight
   # Reject review
-  stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/trains/1.0/builds/10/reject").
+  stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/trains/1.0/builds/10/reject").
     with(body: "{}").
     to_return(status: 200, body: "{}", headers: { 'Content-Type' => 'application/json' })
 
   # Prepare submission
-  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/trains/1.0/builds/10/submit/start").
+  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/trains/1.0/builds/10/submit/start").
     to_return(status: 200, body: itc_read_fixture_file('testflight_submission_start.json'), headers: { 'Content-Type' => 'application/json' })
   # First step of submission
-  stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/trains/1.0/builds/10/submit/start").
+  stub_request(:post, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/trains/1.0/builds/10/submit/start").
     to_return(status: 200, body: itc_read_fixture_file('testflight_submission_submit.json'), headers: { 'Content-Type' => 'application/json' })
 end
 


### PR DESCRIPTION
Seeing this error currently:

```
"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<String>There is no route for the path 'apps/*REMOVED*/trains/1.4.0/builds/*REMOVED*/submit/start'.</String>\n"
```

Seems Apple updated their API a bit. Not sure this PR catches everything, but I at least verified it with
`Spaceship::Tunes.client.submit_testflight_build_for_review!(parameters)` which now works.
