### PR TITLE
Fixed provisioning profile deletion.

### DIFF
--- a/lib/spaceship/portal/portal_client.rb
+++ b/lib/spaceship/portal/portal_client.rb
@@ -377,6 +377,14 @@ module Spaceship
     end
 
     def delete_provisioning_profile!(profile_id, mac: false)
+      if csrf_tokens.count == 0
+        r = request(:post, "account/#{platform_slug(mac)}/profile/getProvisioningProfile.action", {
+          teamId: team_id,
+          provisioningProfileId: profile_id
+        })
+        parse_response(r)
+      end
+
       r = request(:post, "account/#{platform_slug(mac)}/profile/deleteProvisioningProfile.action", {
         teamId: team_id,
         provisioningProfileId: profile_id


### PR DESCRIPTION
To delete a profile it needs to get the profile first. (updates the csrf token)
We could get at least one profile before deleting multiple profiles. But it think it's safer to get it for each deletion.

Fixes #227
