### PR TITLE
Enable updating testing status to external

### DIFF
--- a/lib/spaceship/tunes/build_train.rb
+++ b/lib/spaceship/tunes/build_train.rb
@@ -92,11 +92,11 @@ module Spaceship
           train["#{testing_type}Testing"]['value'] = false
           train["#{testing_type}Testing"]['value'] = new_value if train['versionString'] == version_string
 
-          # also update the builds
+          # find correct build
+          train['builds'].select! { |b| !b["#{testing_type}Testing"].nil? && !build.nil? && b['buildVersion'] == build.build_version }
+
+          # also update the build if it was found
           train['builds'].each do |b|
-            next if b["#{testing_type}Testing"].nil?
-            next if build.nil?
-            next if b["buildVersion"] != build.build_version
             b["#{testing_type}Testing"]['value'] = false
             b["#{testing_type}Testing"]['value'] = new_value if b['trainVersion'] == version_string
           end


### PR DESCRIPTION
To avoid getting `This build could not be used for external testing because the build is not approved.`. Seems like Apple only allows one build. This PR will filter out all other builds.

It's similar to [this pull request](https://github.com/fastlane/spaceship/pull/201/), but using a select-statement instead and not doing the other stuff (which might or might not be useful)
