### PR TITLE
tvOS Profiles

### DIFF
--- a/lib/spaceship/portal/app.rb
+++ b/lib/spaceship/portal/app.rb
@@ -74,12 +74,21 @@ module Spaceship
           self.new(attrs)
         end
 
+        # @deprecated
         # @param mac [Bool] Fetches Mac apps if true
         # @return (Array) Returns all apps available for this account
         def all(mac: false)
-          client.apps(mac: mac).map { |app| self.factory(app) }
+          all(platform: mac ? 'mac' : 'ios')
         end
 
+        # @param platform (String) The platform to fer
+        # @return (Array) Returns all apps available for this account
+        def all(platform: false)
+          client.apps(platform: platform).map { |app| self.factory(app) }
+        end
+
+        # @deprecated
+        #
         # Creates a new App ID on the Apple Dev Portal
         #
         # if bundle_id ends with '*' then it is a wildcard id otherwise, it is an explicit id
@@ -88,21 +97,41 @@ module Spaceship
         # @param mac [Bool] is this a Mac app?
         # @return (App) The app you just created
         def create!(bundle_id: nil, name: nil, mac: false)
+          create!(bundle_id, name, platform: mac ? 'mac' : 'ios')
+        end
+
+        # Creates a new App ID on the Apple Dev Portal
+        #
+        # if bundle_id ends with '*' then it is a wildcard id otherwise, it is an explicit id
+        # @param bundle_id [String] the bundle id (app_identifier) of the app associated with this provisioning profile
+        # @param name [String] the name of the App
+        # @param platform [String] The platform
+        # @return (App) The app you just created
+        def create!(bundle_id: nil, name: nil, platform: 'ios')
           if bundle_id.end_with?('*')
             type = :wildcard
           else
             type = :explicit
           end
 
-          new_app = client.create_app!(type, name, bundle_id, mac: mac)
+          new_app = client.create_app!(type, name, bundle_id, platform: platform)
           self.new(new_app)
         end
 
+        # @deprecated
+        #
         # Find a specific App ID based on the bundle_id
         # @param mac [Bool] Searches Mac apps if true
         # @return (App) The app you're looking for. This is nil if the app can't be found.
         def find(bundle_id, mac: false)
-          all(mac: mac).find do |app|
+          find(bundle_id, platform: mac ? 'mac' : 'ios')
+        end
+
+        # Find a specific App ID based on the bundle_id
+        # @param platform [String] The platform to search for
+        # @return (App) The app you're looking for. This is nil if the app can't be found.
+        def find(bundle_id, platform: 'ios')
+          all(platform: platform).find do |app|
             app.bundle_id == bundle_id
           end
         end
@@ -112,7 +141,7 @@ module Spaceship
       # or there are active profiles
       # @return (App) The app you just deletd
       def delete!
-        client.delete_app!(app_id, mac: mac?)
+        client.delete_app!(app_id, platform: platform)
         self
       end
 

--- a/lib/spaceship/portal/certificate.rb
+++ b/lib/spaceship/portal/certificate.rb
@@ -231,28 +231,43 @@ module Spaceship
           klass.new(attrs)
         end
 
+        # @deprecated
         # @param mac [Bool] Fetches Mac certificates if true. (Ignored if callsed from a subclass)
         # @return (Array) Returns all certificates of this account.
         #  If this is called from a subclass of Certificate, this will
         #  only include certificates matching the current type.
         def all(mac: false)
+          all(platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Fetches Mac certificates if true. (Ignored if callsed from a subclass)
+        # @return (Array) Returns all certificates of this account.
+        #  If this is called from a subclass of Certificate, this will
+        #  only include certificates matching the current type.
+        def all(platform: 'ios')
           if self == Certificate # are we the base-class?
-            type_ids = mac ? MAC_CERTIFICATE_TYPE_IDS : IOS_CERTIFICATE_TYPE_IDS
+            type_ids = platform == 'mac' ? MAC_CERTIFICATE_TYPE_IDS : IOS_CERTIFICATE_TYPE_IDS
             types = type_ids.keys
           else
             types = [CERTIFICATE_TYPE_IDS.key(self)]
-            mac = MAC_CERTIFICATE_TYPE_IDS.values.include? self
           end
 
-          client.certificates(types, mac: mac).map do |cert|
+          client.certificates(types, platform: platform).map do |cert|
             factory(cert)
           end
         end
 
+        # @deprecated
         # @param mac [Bool] Searches Mac certificates if true
         # @return (Certificate) Find a certificate based on the ID of the certificate.
         def find(certificate_id, mac: false)
-          all(mac: mac).find do |c|
+          find(certificate_id, platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Searches Mac certificates if true
+        # @return (Certificate) Find a certificate based on the ID of the certificate.
+        def find(certificate_id, platform: 'ios')
+          all(platform: platform).find do |c|
             c.id == certificate_id
           end
         end
@@ -295,7 +310,7 @@ module Spaceship
 
       # @return (String) Download the raw data of the certificate without parsing
       def download_raw
-        client.download_certificate(id, type_display_id, mac: mac?)
+        client.download_certificate(id, type_display_id, platform: mac? ? 'mac' : 'ios')
       end
 
       # @return (OpenSSL::X509::Certificate) Downloads and parses the certificate
@@ -305,7 +320,7 @@ module Spaceship
 
       # Revoke the certificate. You shouldn't use this method probably.
       def revoke!
-        client.revoke_certificate!(id, type_display_id, mac: mac?)
+        client.revoke_certificate!(id, type_display_id, platform: mac? ? 'mac' : 'ios')
       end
 
       # @return (Bool): Is this certificate a push profile for apps?

--- a/lib/spaceship/portal/device.rb
+++ b/lib/spaceship/portal/device.rb
@@ -58,10 +58,17 @@ module Spaceship
           self.new(attrs)
         end
 
+        # @deprecated
         # @param mac [Bool] Fetches Mac devices if true
         # @return (Array) Returns all devices registered for this account
         def all(mac: false)
-          client.devices(mac: mac).map { |device| self.factory(device) }
+          all(platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Fetches devices of a specific platform
+        # @return (Array) Returns all devices registered for this account
+        def all(platform: 'ios')
+          client.devices(platform: platform).map { |device| self.factory(device) }
         end
 
         # @return (Array) Returns all Apple TVs registered for this account
@@ -91,7 +98,7 @@ module Spaceship
 
         # @return (Array) Returns all Macs registered for this account
         def all_macs
-          all(mac: true)
+          all(platform: 'mac')
         end
 
         # @return (Array) Returns all devices that can be used for iOS profiles (all devices except TVs)
@@ -108,31 +115,54 @@ module Spaceship
           end
         end
 
+        # @deprecated
         # @param mac [Bool] Searches for Macs if true
         # @return (Device) Find a device based on the ID of the device. *Attention*:
         #  This is *not* the UDID. nil if no device was found.
         def find(device_id, mac: false)
-          all(mac: mac).find do |device|
+          find(device_id, platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Searches for specified platform
+        # @return (Device) Find a device based on the ID of the device. *Attention*:
+        #  This is *not* the UDID. nil if no device was found.
+        def find(device_id, platform: 'ios')
+          all(platform: platform).find do |device|
             device.id == device_id
           end
         end
 
+        # @deprecated
         # @param mac [Bool] Searches for Macs if true
         # @return (Device) Find a device based on the UDID of the device. nil if no device was found.
         def find_by_udid(device_udid, mac: false)
-          all(mac: mac).find do |device|
+          find_by_udid(device_udid, platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Searches for specified platform
+        # @return (Device) Find a device based on the UDID of the device. nil if no device was found.
+        def find_by_udid(device_udid, platform: 'ios')
+          all(platform: platform).find do |device|
             device.udid == device_udid
           end
         end
 
+        # @deprecated
         # @param mac [Bool] Searches for Macs if true
         # @return (Device) Find a device based on its name. nil if no device was found.
         def find_by_name(device_name, mac: false)
-          all(mac: mac).find do |device|
+          find_by_name(device_name, platform: mac ? 'mac' : 'ios')
+        end
+
+        # @param platform [String] Searches for specified platform
+        # @return (Device) Find a device based on its name. nil if no device was found.
+        def find_by_name(device_name, platform: 'ios')
+          all(platform: platform).find do |device|
             device.name == device_name
           end
         end
 
+        # @deprecated
         # Register a new device to this account
         # @param name (String) (required): The name of the new device
         # @param udid (String) (required): The UDID of the new device
@@ -141,18 +171,29 @@ module Spaceship
         #   Spaceship.device.create!(name: "Felix Krause's iPhone 6", udid: "4c24a7ee5caaa4847f49aaab2d87483053f53b65")
         # @return (Device): The newly created device
         def create!(name: nil, udid: nil, mac: false)
+          create!(name, udid, platform: mac ? 'mac' : 'ios')
+        end
+
+        # Register a new device to this account
+        # @param name (String) (required): The name of the new device
+        # @param udid (String) (required): The UDID of the new device
+        # @param platform (String) (optional): The platform of the device
+        # @example
+        #   Spaceship.device.create!(name: "Felix Krause's iPhone 6", udid: "4c24a7ee5caaa4847f49aaab2d87483053f53b65")
+        # @return (Device): The newly created device
+        def create!(name: nil, udid: nil, platform: 'ios')
           # Check whether the user has passed in a UDID and a name
           unless udid && name
             raise "You cannot create a device without a device_id (UDID) and name"
           end
 
           # Find the device by UDID, raise an exception if it already exists
-          existing = self.find_by_udid(udid, mac: mac)
+          existing = self.find_by_udid(udid, platform: platform)
           return existing if existing
 
           # It is valid to have the same name for multiple devices
 
-          device = client.create_device!(name, udid, mac: mac)
+          device = client.create_device!(name, udid, platform: platform)
 
           # Update self with the new device
           self.new(device)

--- a/lib/spaceship/portal/provisioning_profile.rb
+++ b/lib/spaceship/portal/provisioning_profile.rb
@@ -238,6 +238,8 @@ module Spaceship
               # For Development and AdHoc we usually want all compatible devices by default
               if platform == 'mac'
                 devices = Spaceship::Device.all_macs
+              elsif platform == 'ios' and !sub_platform.nil? and sub_platform.downcase == 'tvos'
+                devices = Spaceship::Device.all_apple_tvs
               else
                 devices = Spaceship::Device.all_for_profile_type(self.type)
               end

--- a/lib/spaceship/portal/provisioning_profile.rb
+++ b/lib/spaceship/portal/provisioning_profile.rb
@@ -59,9 +59,14 @@ module Spaceship
       attr_accessor :version
 
       # @return (String) The supported platform for this profile
-      # @example
+      # @example iOS
       #   "ios"
       attr_accessor :platform
+
+      # @return (String) The supported platform for this profile
+      # @example tvOS
+      #   "tvOS"
+      attr_accessor :sub_platform
 
       # No information about this attribute
       attr_accessor :managing_app
@@ -183,6 +188,7 @@ module Spaceship
           name.split('::').last
         end
 
+        # @deprecated
         # Create a new provisioning profile
         # @param name (String): The name of the provisioning profile on the Dev Portal
         # @param bundle_id (String): The app identifier, this paramter is required
@@ -195,10 +201,25 @@ module Spaceship
         # @param mac (Bool) (optional): Pass true if you're making a Mac provisioning profile
         # @return (ProvisioningProfile): The profile that was just created
         def create!(name: nil, bundle_id: nil, certificate: nil, devices: [], mac: false)
+          create!(name, bundle_id, certificate, devices, platform: mac ? 'mac' : 'ios')
+        end
+
+        # Create a new provisioning profile
+        # @param name (String): The name of the provisioning profile on the Dev Portal
+        # @param bundle_id (String): The app identifier, this paramter is required
+        # @param certificate (Certificate): The certificate that should be used with this
+        #   provisioning profile. You can also pass an array of certificates to this method. This will
+        #   only work for development profiles
+        # @param devices (Array) (optional): An array of Device objects that should be used in this profile.
+        #  It is recommend to not pass devices as spaceship will automatically add all devices for AdHoc
+        #  and Development profiles and add none for AppStore and Enterprise Profiles
+        # @param platform (String) (optional): The platform that we are creating for
+        # @return (ProvisioningProfile): The profile that was just created
+        def create!(name: nil, bundle_id: nil, certificate: nil, devices: [], platform: 'ios', sub_platform: nil)
           raise "Missing required parameter 'bundle_id'" if bundle_id.to_s.empty?
           raise "Missing required parameter 'certificate'. e.g. use `Spaceship::Certificate::Production.all.first`" if certificate.to_s.empty?
 
-          app = Spaceship::App.find(bundle_id, mac: mac)
+          app = Spaceship::App.find(bundle_id, platform: platform)
           raise "Could not find app with bundle id '#{bundle_id}'" unless app
 
           # Fill in sensible default values
@@ -215,7 +236,7 @@ module Spaceship
           if devices.nil? or devices.count == 0
             if self == Development or self == AdHoc
               # For Development and AdHoc we usually want all compatible devices by default
-              if mac
+              if platform == 'mac'
                 devices = Spaceship::Device.all_macs
               else
                 devices = Spaceship::Device.all_for_profile_type(self.type)
@@ -229,17 +250,26 @@ module Spaceship
                                                 app.app_id,
                                                 certificate_parameter,
                                                 devices.map(&:id),
-                                                mac: mac)
+                                                platform: platform,
+                                                sub_platform: sub_platform)
           end
 
           self.new(profile)
         end
 
+        # @deprecated
         # @return (Array) Returns all profiles registered for this account
         #  If you're calling this from a subclass (like AdHoc), this will
         #  only return the profiles that are of this type
         def all(mac: false)
-          profiles = client.provisioning_profiles(mac: mac).map do |profile|
+          all(platform: mac ? 'mac' : 'ios')
+        end
+
+        # @return (Array) Returns all profiles registered for this account
+        #  If you're calling this from a subclass (like AdHoc), this will
+        #  only return the profiles that are of this type
+        def all(platform: 'ios')
+          profiles = client.provisioning_profiles(platform: platform).map do |profile|
             self.factory(profile)
           end
 
@@ -254,12 +284,21 @@ module Spaceship
           end
         end
 
+        # @deprecated
         # @return (Array) Returns an array of provisioning
         #   profiles matching the bundle identifier
         #   Returns [] if no profiles were found
         #   This may also contain invalid or expired profiles
         def find_by_bundle_id(bundle_id, mac: false)
-          all(mac: mac).find_all do |profile|
+          find_by_bundle_id(bundle_id, platform: mac ? 'mac' : 'ios')
+        end
+
+        # @return (Array) Returns an array of provisioning
+        #   profiles matching the bundle identifier
+        #   Returns [] if no profiles were found
+        #   This may also contain invalid or expired profiles
+        def find_by_bundle_id(bundle_id, platform: 'ios')
+          all(platform: platform).find_all do |profile|
             profile.app.bundle_id == bundle_id
           end
         end
@@ -301,12 +340,12 @@ module Spaceship
       # @example
       #  File.write("path.mobileprovision", profile.download)
       def download
-        client.download_provisioning_profile(self.id, mac: mac?)
+        client.download_provisioning_profile(self.id, platform: platform)
       end
 
       # Delete the provisioning profile
       def delete!
-        client.delete_provisioning_profile!(self.id, mac: mac?)
+        client.delete_provisioning_profile!(self.id, platform: platform)
       end
 
       # Repair an existing provisioning profile
@@ -349,12 +388,13 @@ module Spaceship
             app.app_id,
             certificates.map(&:id),
             devices.map(&:id),
-            mac: mac?
+            platform: platform,
+            sub_platform: sub_platform
           )
         end
 
         # We need to fetch the provisioning profile again, as the ID changes
-        profile = Spaceship::ProvisioningProfile.all(mac: mac?).find do |p|
+        profile = Spaceship::ProvisioningProfile.all(platform: platform).find do |p|
           p.name == self.name # we can use the name as it's valid
         end
 
@@ -366,7 +406,7 @@ module Spaceship
       def certificate_valid?
         return false if (certificates || []).count == 0
         certificates.each do |c|
-          if Spaceship::Certificate.all(mac: mac?).collect(&:id).include?(c.id)
+          if Spaceship::Certificate.all(platform: platform).collect(&:id).include?(c.id)
             return true
           end
         end

--- a/spec/portal/app_spec.rb
+++ b/spec/portal/app_spec.rb
@@ -82,7 +82,7 @@ describe Spaceship::Portal::App do
 
   describe '#create' do
     it 'creates an app id with an explicit bundle_id' do
-      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', mac: false) {
+      expect(client).to receive(:create_app!).with(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app', platform: 'ios') {
         { 'isWildCard' => true }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.some-explicit-app', name: 'Production App')
@@ -90,7 +90,7 @@ describe Spaceship::Portal::App do
     end
 
     it 'creates an app id with a wildcard bundle_id' do
-      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', mac: false) {
+      expect(client).to receive(:create_app!).with(:wildcard, 'Development App', 'tools.fastlane.spaceship.*', platform: 'ios') {
         { 'isWildCard' => false }
       }
       app = Spaceship::Portal::App.create!(bundle_id: 'tools.fastlane.spaceship.*', name: 'Development App')
@@ -101,7 +101,7 @@ describe Spaceship::Portal::App do
   describe '#delete' do
     subject { Spaceship::Portal::App.find("net.sunapps.151") }
     it 'deletes the app by a given bundle_id' do
-      expect(client).to receive(:delete_app!).with('B7JBD8LHAA', mac: false)
+      expect(client).to receive(:delete_app!).with('B7JBD8LHAA', platform: 'ios')
       app = subject.delete!
       expect(app.app_id).to eq('B7JBD8LHAA')
     end

--- a/spec/portal/certificate_spec.rb
+++ b/spec/portal/certificate_spec.rb
@@ -80,7 +80,7 @@ describe Spaceship::Certificate do
   describe '#revoke' do
     let(:cert) { Spaceship::Portal::Certificate.all.first }
     it 'revokes certificate by the given cert id' do
-      expect(client).to receive(:revoke_certificate!).with('XC5PH8DAAA', 'R58UK2EAAA', mac: false)
+      expect(client).to receive(:revoke_certificate!).with('XC5PH8DAAA', 'R58UK2EAAA', platform: 'ios')
       cert.revoke!
     end
   end

--- a/spec/portal/device_spec.rb
+++ b/spec/portal/device_spec.rb
@@ -83,7 +83,7 @@ describe Spaceship::Device do
 
   describe "#create" do
     it "should create and return a new device" do
-      expect(client).to receive(:create_device!).with("Demo Device", "7f6c8dc83d77134b5a3a1c53f1202b395b04482b", mac: false).and_return({})
+      expect(client).to receive(:create_device!).with("Demo Device", "7f6c8dc83d77134b5a3a1c53f1202b395b04482b", platform: 'ios').and_return({})
       device = Spaceship::Device.create!(name: "Demo Device", udid: "7f6c8dc83d77134b5a3a1c53f1202b395b04482b")
     end
 
@@ -105,7 +105,7 @@ describe Spaceship::Device do
     end
 
     it "doesn't raise an exception if the device name is already registered" do
-      expect(client).to receive(:create_device!).with("Personal iPhone", "e5814abb3b1d92087d48b64f375d8e7694932c3c", mac: false).and_return({})
+      expect(client).to receive(:create_device!).with("Personal iPhone", "e5814abb3b1d92087d48b64f375d8e7694932c3c", platform: 'ios').and_return({})
       device = Spaceship::Device.create!(name: "Personal iPhone", udid: "e5814abb3b1d92087d48b64f375d8e7694932c3c")
     end
   end

--- a/spec/provisioning_profile_spec.rb
+++ b/spec/provisioning_profile_spec.rb
@@ -30,6 +30,7 @@ describe Spaceship::ProvisioningProfile do
       expect(profile.class.type).to eq('limited')
       expect(profile.class.pretty_type).to eq('Development')
       expect(profile.type).to eq('iOS Development')
+      expect(profile.sub_platform).to eq(nil)
     end
 
     it 'should filter by the correct types' do
@@ -121,12 +122,12 @@ describe Spaceship::ProvisioningProfile do
 
     it 'creates a new development provisioning profile' do
       expect(Spaceship::Device).to receive(:all).and_return([])
-      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false).and_return({})
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'limited', '2UMR2S6PAA', "XC5PH8DAAA", [], platform: 'ios', sub_platform: nil).and_return({})
       Spaceship::ProvisioningProfile::Development.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
     end
 
     it 'creates a new appstore provisioning profile' do
-      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], mac: false).and_return({})
+      expect(client).to receive(:create_provisioning_profile!).with('Delete Me', 'store', '2UMR2S6PAA', "XC5PH8DAAA", [], platform: 'ios', sub_platform: nil).and_return({})
       Spaceship::ProvisioningProfile::AppStore.create!(name: 'Delete Me', bundle_id: 'net.sunapps.1', certificate: certificate)
     end
 
@@ -135,7 +136,7 @@ describe Spaceship::ProvisioningProfile do
                                                                     'store',
                                                                     '2UMR2S6PAA',
                                                                     "XC5PH8DAAA",
-                                                                    [], mac: false).
+                                                                    [], platform: 'ios', sub_platform: nil).
         and_return({})
       Spaceship::ProvisioningProfile::AppStore.create!(bundle_id: 'net.sunapps.1', certificate: certificate)
     end
@@ -150,7 +151,7 @@ describe Spaceship::ProvisioningProfile do
   describe "#delete" do
     let(:profile) { Spaceship::ProvisioningProfile.all.first }
     it "deletes an existing profile" do
-      expect(client).to receive(:delete_provisioning_profile!).with(profile.id, mac: false).and_return({})
+      expect(client).to receive(:delete_provisioning_profile!).with(profile.id, platform: 'ios').and_return({})
       profile.delete!
     end
   end
@@ -160,24 +161,24 @@ describe Spaceship::ProvisioningProfile do
 
     it "repairs an existing profile with added devices" do
       profile.devices = Spaceship::Device.all_for_profile_type(profile.type)
-      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], mac: false).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], platform: 'ios', sub_platform: nil).and_return({})
       profile.repair!
     end
 
     it "update the certificate if the current one doesn't exist" do
       profile.certificates = []
-      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], mac: false).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], platform: 'ios', sub_platform: nil).and_return({})
       profile.repair!
     end
 
     it "update the certificate if the current one is invalid" do
       expect(profile.certificates.first.id).to eq('XC5PH8D47H') # this was the previous one
-      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], mac: false).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], platform: 'ios', sub_platform: nil).and_return({})
       profile.repair! # repair will replace the old certificate with the new one
     end
 
     it "repairs an existing profile with no devices" do
-      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], mac: false).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], platform: 'ios', sub_platform: nil).and_return({})
       profile.repair!
     end
 
@@ -185,7 +186,7 @@ describe Spaceship::ProvisioningProfile do
       it "Development" do
         profile = Spaceship::ProvisioningProfile::Development.all.first
         devices = ["RK3285QATH", "E687498679", "5YTNZ5A9RV", "VCD3RH54BK", "VA3Z744A8R", "T5VFWSCC2Z", "GD25LDGN99", "XJXGVS46MW", "L4378H292Z", "9T5RA84V77", "S4227Y42V5", "LEL449RZER", "WXQ7V239BE"]
-        expect(client).to receive(:repair_provisioning_profile!).with('475ESRP5F3', 'net.sunapps.7 Development', 'limited', '572XTN75U2', ["C8DL7464RQ"], devices, mac: false).and_return({})
+        expect(client).to receive(:repair_provisioning_profile!).with('475ESRP5F3', 'net.sunapps.7 Development', 'limited', '572XTN75U2', ["C8DL7464RQ"], devices, platform: 'ios', sub_platform: nil).and_return({})
         profile.repair!
       end
     end
@@ -195,7 +196,7 @@ describe Spaceship::ProvisioningProfile do
     let(:profile) { Spaceship::ProvisioningProfile.all.first }
 
     it "updates an existing profile" do
-      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], mac: false).and_return({})
+      expect(client).to receive(:repair_provisioning_profile!).with('2MAY7NPHRU', 'net.sunapps.7 AppStore', 'store', '572XTN75U2', ["C8DL7464RQ"], [], platform: 'ios', sub_platform: nil).and_return({})
       profile.update!
     end
   end


### PR DESCRIPTION
This aims to fix #229.  i have deprecated the `mac: false` params in favor of `platform: 'ios'` This will ensure future compatibility with newer platforms as they come out. (or older ones if apple decides to change tvOS and watchOS)

I have also added the sub_platform option to the provisioning profiles.
