### PR TITLE
Update to new ITC API related to #228 (application.platform/version/versionSets)

### DIFF
--- a/lib/spaceship/tunes/app_version.rb
+++ b/lib/spaceship/tunes/app_version.rb
@@ -159,8 +159,11 @@ module Spaceship
         # @param app_id (String) The unique Apple ID of this app
         # @param is_live (Boolean)
         def find(application, app_id, is_live)
+          # too bad the "id" field is empty, it forces us to make more requests to the server
+          # these could also be cached
           attrs = client.app_version(app_id, is_live)
           return nil unless attrs
+
           attrs.merge!(application: application)
           attrs.merge!(is_live: is_live)
 

--- a/lib/spaceship/tunes/app_version.rb
+++ b/lib/spaceship/tunes/app_version.rb
@@ -159,6 +159,10 @@ module Spaceship
         # @param app_id (String) The unique Apple ID of this app
         # @param is_live (Boolean)
         def find(application, app_id, is_live)
+          # we only support applications
+          platform = Spaceship::Tunes::AppVersionCommon.find_platform(application.raw_data['versionSets'])
+          raise "We do not support BUNDLE types right now" if platform['type'] == 'BUNDLE'
+
           # too bad the "id" field is empty, it forces us to make more requests to the server
           # these could also be cached
           attrs = client.app_version(app_id, is_live)

--- a/lib/spaceship/tunes/app_version_common.rb
+++ b/lib/spaceship/tunes/app_version_common.rb
@@ -1,0 +1,31 @@
+module Spaceship
+  module Tunes
+    # internal to spaceship
+    # Represents the common structure between application['versionSets'] and app_version['platform']
+    class AppVersionCommon
+      class << self
+        def find_version_id(platform, is_live)
+          version = platform[(is_live ? 'deliverableVersion' : 'inFlightVersion')]
+          return nil unless version
+          version['id']
+        end
+
+        def find_platform(versions)
+          # We only support platforms that exist ATM
+          platform = versions.detect do |p|
+            ['ios', 'osx', 'appletvos'].include? p['platformString']
+          end
+
+          raise "Could not find platform ios, osx or appletvos for app #{app_id}" unless platform
+
+          # If your app has versions for both iOS and tvOS we will default to returning the iOS version for now.
+          # This is intentional as we need to do more work to support apps that have hybrid versions.
+          if versions.length > 1
+            platform = versions.detect { |p| p['platformString'] == "ios" }
+          end
+          platform
+        end
+      end
+    end
+  end
+end

--- a/lib/spaceship/tunes/application.rb
+++ b/lib/spaceship/tunes/application.rb
@@ -11,11 +11,6 @@ module Spaceship
       #   "Spaceship App"
       attr_accessor :name
 
-      # @return (String) the supported platform of this app
-      # @example
-      #   "ios"
-      attr_accessor :platform
-
       # @return (String) The Vendor ID provided by iTunes Connect
       # @example
       #   "1435592086"
@@ -42,7 +37,6 @@ module Spaceship
       attr_mapping(
         'adamId' => :apple_id,
         'name' => :name,
-        'appType' => :platform,
         'vendorId' => :vendor_id,
         'bundleId' => :bundle_id,
         'lastModifiedDate' => :last_modified,
@@ -100,13 +94,6 @@ module Spaceship
       # @return (Spaceship::AppVersion) Receive the version that is currently live on the
       #  App Store. You can't modify all values there, so be careful.
       def live_version
-        if (raw_data['versions'] || []).count == 1
-          v = raw_data['versions'].last
-          if ['Prepare for Upload', 'prepareForUpload'].include?(v['state']) # this only applies for the initial version
-            return nil
-          end
-        end
-
         Spaceship::AppVersion.find(self, self.apple_id, true)
       end
 
@@ -116,9 +103,9 @@ module Spaceship
       end
 
       # @return (Spaceship::AppVersion) This will return the `edit_version` if available
-      #   and fallback to the `edit_version`. Use this to just access the latest data
+      #   and fallback to the `live_version`. Use this to just access the latest data
       def latest_version
-        edit_version || live_version || Spaceship::AppVersion.find(self, self.apple_id, false) # we want to get *any* version, prefered the latest one
+        edit_version || live_version
       end
 
       # @return (String) An URL to this specific resource. You can enter this URL into your browser
@@ -131,6 +118,14 @@ module Spaceship
       #  `{"sectionErrorKeys"=>[], "sectionInfoKeys"=>[], "sectionWarningKeys"=>[], "replyConstraints"=>{"minLength"=>1, "maxLength"=>4000}, "appNotes"=>{"threads"=>[]}, "betaNotes"=>{"threads"=>[]}, "appMessages"=>{"threads"=>[]}}`
       def resolution_center
         client.get_resolution_center(apple_id, platform)
+      end
+
+      # kept for backward compatibility
+      # tries to guess the platform of the currently submitted apps
+      # note that as ITC now supports multiple app types, this might break
+      # if your app supports more than one
+      def platform
+        Spaceship::Tunes::AppVersionCommon.find_platform(raw_data['versionSets'])['platformString']
       end
 
       def details

--- a/lib/spaceship/tunes/tunes.rb
+++ b/lib/spaceship/tunes/tunes.rb
@@ -1,6 +1,7 @@
 require 'spaceship/tunes/tunes_base'
 require 'spaceship/tunes/application'
 require 'spaceship/tunes/app_version'
+require 'spaceship/tunes/app_version_common'
 require 'spaceship/tunes/app_submission'
 require 'spaceship/tunes/tunes_client'
 require 'spaceship/tunes/language_item'

--- a/lib/spaceship/tunes/tunes_client.rb
+++ b/lib/spaceship/tunes/tunes_client.rb
@@ -324,23 +324,21 @@ module Spaceship
       r = request(:get, "ra/apps/#{app_id}/overview")
       platforms = parse_response(r, 'data')['platforms']
 
-      # We only support platforms that exist ATM
-      platform = platforms.find do |p|
-        ['ios', 'osx', 'appletvos'].include? p['platformString']
-      end
+      platform = Spaceship::Tunes::AppVersionCommon.find_platform(platforms)
+      return nil unless platform
 
-      raise "Could not find platform ios, osx or appletvos for app #{app_id}" unless platform
+      version_id = Spaceship::Tunes::AppVersionCommon.find_version_id(platform, is_live)
+      return nil unless version_id
 
-      # If your app has versions for both iOS and tvOS we will default to returning the iOS version for now.
-      # This is intentional as we need to do more work to support apps that have hybrid versions.
-      if platforms.length > 1
-        platform = platforms.detect { |p| p['platformString'] == "ios" }
-      end
-
-      version = platform[(is_live ? 'deliverableVersion' : 'inFlightVersion')]
-      return nil unless version
-      version_id = version['id']
       version_platform = platform['platformString']
+
+      app_version_data(app_id, version_platform: version_platform, version_id: version_id)
+    end
+
+    def app_version_data(app_id, version_platform: nil, version_id:nil)
+      raise "app_id is required" unless app_id
+      raise "version_platform is required" unless version_platform
+      raise "version_id is required" unless version_id
 
       r = request(:get, "ra/apps/#{app_id}/platforms/#{version_platform}/versions/#{version_id}")
       parse_response(r, 'data')

--- a/spec/tunes/application_spec.rb
+++ b/spec/tunes/application_spec.rb
@@ -10,7 +10,7 @@ describe Spaceship::Application do
     end
 
     it "the number is correct" do
-      expect(Spaceship::Application.all.count).to eq(7)
+      expect(Spaceship::Application.all.count).to eq(8)
     end
 
     it "parses application correctly" do
@@ -175,6 +175,25 @@ describe Spaceship::Application do
           expect(app.live_version).to eq(nil)
           expect(app.edit_version.is_live).to eq(false)
           expect(app.latest_version.is_live).to eq(false)
+        end
+      end
+
+      describe "BUNDLES", focus: true do
+        let (:bundle) { Spaceship::Application.find(928_444_013) }
+        it "can find a bundle" do
+          expect(bundle.raw_data['type']).to eq("iOS App Bundle")
+        end
+
+        it "fails to find the edit_version of a bundle" do
+          expect do
+            bundle.edit_version
+          end.to raise_error('We do not support BUNDLE types right now')
+        end
+
+        it "fails to find the live_version of a bundle" do
+          expect do
+            bundle.live_version
+          end.to raise_error('We do not support BUNDLE types right now')
         end
       end
     end

--- a/spec/tunes/application_spec.rb
+++ b/spec/tunes/application_spec.rb
@@ -10,7 +10,7 @@ describe Spaceship::Application do
     end
 
     it "the number is correct" do
-      expect(Spaceship::Application.all.count).to eq(6)
+      expect(Spaceship::Application.all.count).to eq(7)
     end
 
     it "parses application correctly" do
@@ -166,6 +166,15 @@ describe Spaceship::Application do
           v = Spaceship::Application.all.first.live_version
           expect(v.class).to eq(Spaceship::AppVersion)
           expect(v.is_live).to eq(true)
+        end
+      end
+
+      describe "#live_version weirdities", focus: true do
+        it "no live version if app isn't yet uploaded" do
+          app = Spaceship::Application.find(1_000_000_000)
+          expect(app.live_version).to eq(nil)
+          expect(app.edit_version.is_live).to eq(false)
+          expect(app.latest_version.is_live).to eq(false)
         end
       end
     end

--- a/spec/tunes/application_spec.rb
+++ b/spec/tunes/application_spec.rb
@@ -25,7 +25,7 @@ describe Spaceship::Application do
       expect(app.issues_count).to eq(0)
       expect(app.app_icon_preview_url).to eq('https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/340x340bb-80.png')
 
-      expect(app.raw_data['versions'].count).to eq(2)
+      expect(app.raw_data['versionSets'].count).to eq(1)
     end
 
     it "#url" do
@@ -169,7 +169,7 @@ describe Spaceship::Application do
         end
       end
 
-      describe "#live_version weirdities", focus: true do
+      describe "#live_version weirdities" do
         it "no live version if app isn't yet uploaded" do
           app = Spaceship::Application.find(1_000_000_000)
           expect(app.live_version).to eq(nil)

--- a/spec/tunes/fixtures/app_overview_stuckinprepare.json
+++ b/spec/tunes/fixtures/app_overview_stuckinprepare.json
@@ -1,0 +1,54 @@
+{
+  "data": {
+    "sectionErrorKeys": [],
+    "sectionInfoKeys": [],
+    "sectionWarningKeys": [],
+    "adamId": "1000000000",
+    "primaryLocaleCode": "en-US",
+    "features": ["PRERELEASE", "PRICING", "GAMECENTER"],
+    "appTransferState": null,
+    "localizedMetadata": [{
+      "localeCode": "en-US",
+      "name": "Updated by fastlane"
+    }, {
+      "localeCode": "de-DE",
+      "name": "why new itc 2"
+    }],
+    "platforms": [{
+      "type": "APP",
+      "platformString": "ios",
+      "inFlightVersion": {
+        "type": "APP",
+        "id": "800000000",
+        "version": "1.0",
+        "state": "prepareForUpload",
+        "stateKey": "prepareForUpload",
+        "stateGroup": "preRelease",
+        "largeAppIcon": {
+          "assetToken": "Purple3/v4/42/45/f2/4245f2ee-3a37-a34d-a659-1f5f403ab2fe/pr_source.png",
+          "sortOrder": null,
+          "url": "https://is3-ssl.mzstatic.com/image/thumb/Purple3/v4/42/45/f2/4245f2ee-3a37-a34d-a659-1f5f403ab2fe/pr_source.png/1024x1024ss-80.png",
+          "thumbNailUrl": "https://is3-ssl.mzstatic.com/image/thumb/Purple3/v4/42/45/f2/4245f2ee-3a37-a34d-a659-1f5f403ab2fe/pr_source.png/500x500bb-80.png",
+          "originalFileName": "noalpha.png"
+        },
+        "supportedHardware": ["iphone"],
+        "issuesCount": 0
+      }
+    }],
+    "allowedNewVersionPlatforms": [],
+    "submittablePlatforms": ["ios", "osx", "appletvos"],
+    "appStoreUrl": "https://itunes.apple.com/us/app/why-new-itc-2/id1039164429?ls=1&mt=8",
+    "analyticsUrl": null,
+    "salesAndTrendsUrl": null,
+    "canCreateAddOn": true,
+    "everSubmittedAnAddon": false,
+    "everSubmittedFreeSubscriptionAddon": true,
+    "freeSubscriptionAddonCount": 0
+  },
+  "messages": {
+    "warn": null,
+    "error": null,
+    "info": null
+  },
+  "statusCode": "SUCCESS"
+}

--- a/spec/tunes/fixtures/app_summary.json
+++ b/spec/tunes/fixtures/app_summary.json
@@ -8,102 +8,119 @@
     "cloudStorageLink": "/WebObjects/iTunesConnect.woa/ra/apps/manageyourapps/summary/cloudstorage",
     "catalogReportsLink": "/WebObjects/iTunesConnect.woa/ra/apps/manageyourapps/summary/catalogreports",
     "sharedSecretLink": "/WebObjects/iTunesConnect.woa/ra/apps/manageyourapps/summary/sharedsecret",
+    "contractAnnouncements": [],
+    "enabledPlatforms": ["ios", "osx", "appletvos"],
     "canCreateIOSApps": true,
     "summaries": [{
       "adamId": "898536088",
       "name": "App Name 1",
       "vendorId": "107",
       "bundleId": "net.sunapps.107",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "0.9.8",
-        "state": "Ready for Sale",
-        "stateKey": "readyForSale",
-        "stateGroup": "readyForSale",
-        "largeAppIcon": {
-          "assetToken": "Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png",
-          "url": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/1024x1024ss-80.png",
-          "thumbNailUrl": "https://is4-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/500x500bb-80.png",
-          "sortOrder": null,
-          "originalFileName": "appicon.png"
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "0.9.8",
+          "state": "Ready for Sale",
+          "stateKey": "readyForSale",
+          "stateGroup": "readyForSale",
+          "largeAppIcon": {
+            "assetToken": "Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png",
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/1024x1024ss-80.png",
+            "thumbNailUrl": "https://is4-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/500x500bb-80.png",
+            "sortOrder": null,
+            "originalFileName": "appicon.png"
+          },
+          "supportedHardware": ["iphone"],
+          "issuesCount": 0
         },
-        "supportedHardware": ["iphone"],
-        "issuesCount": 0
-      }, {
-        "id": null,
-        "version": "1.0",
-        "state": "Prepare for Upload",
-        "stateKey": "prepareForUpload",
-        "stateGroup": "preRelease",
-        "largeAppIcon": {
-          "assetToken": "Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png",
-          "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png/1024x1024ss-80.png",
-          "thumbNailUrl": "https://is2-ssl.mzstatic.com/image/thumb/Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png/500x500bb-80.png",
-          "sortOrder": null,
-          "originalFileName": "appicon.png"
-        },
-        "supportedHardware": ["iphone"],
-        "issuesCount": 0
-      }],
-      "versionSets": null,
-      "buildVersionSets": null,
+        "deliverableVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "1.0",
+          "state": "Prepare for Upload",
+          "stateKey": "prepareForUpload",
+          "stateGroup": "preRelease",
+          "largeAppIcon": {
+            "assetToken": "Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png",
+            "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png/1024x1024ss-80.png",
+            "thumbNailUrl": "https://is2-ssl.mzstatic.com/image/thumb/Purple4/v4/64/7a/e3/647ae3c4-033b-afcd-5af3-65ccb7240dc9/mzl.zybzvfar.png/500x500bb-80.png",
+            "sortOrder": null,
+            "originalFileName": "appicon.png"
+          },
+          "supportedHardware": ["iphone"],
+          "issuesCount": 0
+        }
+      }
+      ],
+      "buildVersionSets": [],
       "lastModifiedDate": 1435685244000,
       "iconUrl": "https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/340x340bb-80.png",
-      "issuesCount": 0,
-      "type": "ios"
+      "issuesCount": 0
     }, {
       "adamId": "1013943394",
       "name": "app name why not",
       "vendorId": "1435592086",
       "bundleId": "net.sunapps.realtestda",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "1.0",
-        "state": "prepareForUpload",
-        "stateKey": "prepareForUpload",
-        "stateGroup": "preRelease",
-        "largeAppIcon": {
-          "assetToken": null,
-          "url": null,
-          "thumbNailUrl": null,
-          "sortOrder": null,
-          "originalFileName": null
-        },
-        "supportedHardware": [],
-        "issuesCount": 0
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": null,
+        "deliverableVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "1.0",
+          "state": "prepareForUpload",
+          "stateKey": "prepareForUpload",
+          "stateGroup": "preRelease",
+          "largeAppIcon": {
+            "assetToken": null,
+            "url": null,
+            "thumbNailUrl": null,
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": [],
+          "issuesCount": 0
+        }
       }],
-      "versionSets": null,
-      "buildVersionSets": null,
+      "buildVersionSets": [],
       "lastModifiedDate": 1435596669000,
       "iconUrl": null,
-      "issuesCount": 0,
-      "type": "ios"
+      "issuesCount": 0
     }, {
       "adamId": "1006641907",
       "name": "App Name 3",
       "vendorId": "187",
       "bundleId": "net.sunapps.187",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "0.9.13",
-        "state": "waitingForReview",
-        "stateKey": "waitingForReview",
-        "stateGroup": "preRelease",
-        "largeAppIcon": {
-          "assetToken": "Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png",
-          "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png/500x500bb-80.png",
-          "thumbNailUrl": "https://is3-ssl.mzstatic.com/image/thumb/Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png/340x340bb-80.png",
-          "sortOrder": null,
-          "originalFileName": null
-        },
-        "supportedHardware": ["iPhone"],
-        "issuesCount": 0
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": null,
+        "deliverableVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "0.9.13",
+          "state": "waitingForReview",
+          "stateKey": "waitingForReview",
+          "stateGroup": "preRelease",
+          "largeAppIcon": {
+            "assetToken": "Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png",
+            "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png/500x500bb-80.png",
+            "thumbNailUrl": "https://is3-ssl.mzstatic.com/image/thumb/Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png/340x340bb-80.png",
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": ["iPhone"],
+          "issuesCount": 0
+        }
       }],
-      "versionSets": null,
-      "buildVersionSets": null,
+      "buildVersionSets": [],
       "lastModifiedDate": 1435219008000,
       "iconUrl": "https://is3-ssl.mzstatic.com/image/thumb/Purple5/v4/ac/90/92/ac909277-6706-f204-22d8-3736d10c1d85/pr_source.png/340x340bb-80.png",
       "issuesCount": 0,
@@ -113,25 +130,30 @@
       "name": "Profi App",
       "vendorId": "191",
       "bundleId": "net.sunapps.191",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "0.9.13",
-        "state": "readyForSale",
-        "stateKey": "readyForSale",
-        "stateGroup": "readyForSale",
-        "largeAppIcon": {
-          "assetToken": "Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png",
-          "url": "https://is2-ssl.mzstatic.com/image/thumb/Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png/500x500bb-80.png",
-          "thumbNailUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png/340x340bb-80.png",
-          "sortOrder": null,
-          "originalFileName": null
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "0.9.13",
+          "state": "readyForSale",
+          "stateKey": "readyForSale",
+          "stateGroup": "readyForSale",
+          "largeAppIcon": {
+            "assetToken": "Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png",
+            "url": "https://is2-ssl.mzstatic.com/image/thumb/Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png/500x500bb-80.png",
+            "thumbNailUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png/340x340bb-80.png",
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": ["iPhone"],
+          "issuesCount": 0
         },
-        "supportedHardware": ["iPhone"],
-        "issuesCount": 0
+        "deliverableVersion": null
       }],
-      "versionSets": null,
-      "buildVersionSets": null,
+      "buildVersionSets": [],
       "lastModifiedDate": 1435193552000,
       "iconUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple7/v4/cd/a3/e2/cda3e2ac-4034-c6af-ee0c-3e4d9a0baf07/pr_source.png/340x340bb-80.png",
       "issuesCount": 0,
@@ -141,25 +163,30 @@
       "name": "Colorbook / Szene-Eventmagazin",
       "vendorId": "192",
       "bundleId": "net.sunapps.192",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "0.9.13",
-        "state": "readyForSale",
-        "stateKey": "readyForSale",
-        "stateGroup": "readyForSale",
-        "largeAppIcon": {
-          "assetToken": "Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png",
-          "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png/500x500bb-80.png",
-          "thumbNailUrl": "https://is5-ssl.mzstatic.com/image/thumb/Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png/340x340bb-80.png",
-          "sortOrder": null,
-          "originalFileName": null
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "0.9.13",
+          "state": "readyForSale",
+          "stateKey": "readyForSale",
+          "stateGroup": "readyForSale",
+          "largeAppIcon": {
+            "assetToken": "Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png",
+            "url": "https://is4-ssl.mzstatic.com/image/thumb/Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png/500x500bb-80.png",
+            "thumbNailUrl": "https://is5-ssl.mzstatic.com/image/thumb/Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png/340x340bb-80.png",
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": ["iPhone"],
+          "issuesCount": 0
         },
-        "supportedHardware": ["iPhone"],
-        "issuesCount": 0
+        "deliverableVersion": null
       }],
-      "versionSets": null,
-      "buildVersionSets": null,
+      "buildVersionSets": [],
       "lastModifiedDate": 1434068792000,
       "iconUrl": "https://is5-ssl.mzstatic.com/image/thumb/Purple1/v4/52/18/05/521805d6-ecf0-8d75-5406-f2fa4ab02317/pr_source.png/340x340bb-80.png",
       "issuesCount": 0,
@@ -169,25 +196,30 @@
       "name": "Yes",
       "vendorId": "23",
       "bundleId": "net.sunapps.23",
-      "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "0.9.13",
-        "state": "readyForSale",
-        "stateKey": "readyForSale",
-        "stateGroup": "readyForSale",
-        "largeAppIcon": {
-          "assetToken": "Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png",
-          "url": "https://is2-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/500x500bb-80.png",
-          "thumbNailUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/340x340bb-80.png",
-          "sortOrder": null,
-          "originalFileName": null
+      "appType": null,
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": {
+          "type": "APP",
+          "id": null,
+          "version": "0.9.13",
+          "state": "readyForSale",
+          "stateKey": "readyForSale",
+          "stateGroup": "readyForSale",
+          "largeAppIcon": {
+            "assetToken": "Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png",
+            "url": "https://is2-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/500x500bb-80.png",
+            "thumbNailUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/340x340bb-80.png",
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": ["iPhone"],
+          "issuesCount": 0
         },
-        "supportedHardware": ["iPhone"],
-        "issuesCount": 0
+        "deliverableVersion": null
       }],
-      "versionSets": null,
-      "buildVersionSets": null,
+      "buildVersionSets": [],
       "lastModifiedDate": 1434068779000,
       "iconUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/340x340bb-80.png",
       "issuesCount": 0,
@@ -198,23 +230,27 @@
       "vendorId": "1435592086",
       "bundleId": "net.sunapps.stuckinprepare",
       "appType": "ios",
-      "versions": [{
-        "id": null,
-        "version": "1.0",
-        "state": "prepareForUpload",
-        "stateKey": "prepareForUpload",
-        "stateGroup": "preRelease",
-        "largeAppIcon": {
-          "assetToken": null,
-          "url": null,
-          "thumbNailUrl": null,
-          "sortOrder": null,
-          "originalFileName": null
+      "versionSets": [{
+        "type": "APP",
+        "platformString": "ios",
+        "inFlightVersion": {
+          "id": null,
+          "version": "1.0",
+          "state": "prepareForUpload",
+          "stateKey": "prepareForUpload",
+          "stateGroup": "preRelease",
+          "largeAppIcon": {
+            "assetToken": null,
+            "url": null,
+            "thumbNailUrl": null,
+            "sortOrder": null,
+            "originalFileName": null
+          },
+          "supportedHardware": [],
+          "issuesCount": 0
         },
-        "supportedHardware": [],
-        "issuesCount": 0
+        "deliverableVersion": null
       }],
-      "versionSets": null,
       "buildVersionSets": null,
       "lastModifiedDate": 1435596669000,
       "iconUrl": null,

--- a/spec/tunes/fixtures/app_summary.json
+++ b/spec/tunes/fixtures/app_summary.json
@@ -192,6 +192,34 @@
       "iconUrl": "https://is1-ssl.mzstatic.com/image/thumb/Purple3/v4/22/90/85/229085ce-4cbb-9311-4470-277dcc7d616e/pr_source.png/340x340bb-80.png",
       "issuesCount": 0,
       "type": "ios"
+    },{
+      "adamId": "1000000000",
+      "name": "app name why not",
+      "vendorId": "1435592086",
+      "bundleId": "net.sunapps.stuckinprepare",
+      "appType": "ios",
+      "versions": [{
+        "id": null,
+        "version": "1.0",
+        "state": "prepareForUpload",
+        "stateKey": "prepareForUpload",
+        "stateGroup": "preRelease",
+        "largeAppIcon": {
+          "assetToken": null,
+          "url": null,
+          "thumbNailUrl": null,
+          "sortOrder": null,
+          "originalFileName": null
+        },
+        "supportedHardware": [],
+        "issuesCount": 0
+      }],
+      "versionSets": null,
+      "buildVersionSets": null,
+      "lastModifiedDate": 1435596669000,
+      "iconUrl": null,
+      "issuesCount": 0,
+      "type": "ios"
     }],
     "canCreateAppBundles": true
   },

--- a/spec/tunes/fixtures/app_summary.json
+++ b/spec/tunes/fixtures/app_summary.json
@@ -256,6 +256,36 @@
       "iconUrl": null,
       "issuesCount": 0,
       "type": "ios"
+    }, {
+      "adamId": "928444013",
+      "name": "DragonBox Full Algebra Pack",
+      "vendorId": "20141010004",
+      "type": "iOS App Bundle",
+      "versions": null,
+      "versionSets": [{
+        "type": "BUNDLE",
+        "platformString": "ios",
+        "inFlightVersion": null,
+        "deliverableVersion": {
+          "type": "BUNDLE",
+          "version": null,
+          "state": "Developer Removed from Sale",
+          "stateGroup": "notForSale",
+          "stateKey": "developerRemovedFromSale",
+          "supportedHardware": ["ipad", "iphone"],
+          "issuesCount": 0,
+          "largeAppIcon": {
+            "assetToken": null,
+            "sortOrder": null,
+            "type": null,
+            "url": null,
+            "thumbNailUrl": null,
+            "originalFileName": null
+          }
+        }
+      }],
+      "lastModifiedDate": 1443771230000,
+      "iconUrl": "https://s5.mzstatic.com/us/r30/Purple1/v4/56/4a/b1/564ab13c-142f-bfc9-1a6d-598c017fe9a2/icon340x340.png"
     }],
     "canCreateAppBundles": true
   },

--- a/spec/tunes/tunes_stubbing.rb
+++ b/spec/tunes/tunes_stubbing.rb
@@ -50,6 +50,9 @@ def itc_stub_applications
   stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/overview").
     to_return(status: 200, body: itc_read_fixture_file('app_overview.json'), headers: { 'Content-Type' => 'application/json' })
 
+  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/1000000000/overview").
+    to_return(status: 200, body: itc_read_fixture_file('app_overview_stuckinprepare.json'), headers: { 'Content-Type' => 'application/json' })
+
   # App Details
   stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/details").
     to_return(status: 200, body: itc_read_fixture_file('app_details.json'), headers: { 'Content-Type' => 'application/json' })
@@ -87,6 +90,8 @@ def itc_stub_app_versions
   stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/versions/813314674").
     to_return(status: 200, body: itc_read_fixture_file('app_version.json'), headers: { 'Content-Type' => 'application/json' })
   stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/versions/113314675").
+    to_return(status: 200, body: itc_read_fixture_file('app_version.json'), headers: { 'Content-Type' => 'application/json' })
+  stub_request(:get, "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/1000000000/platforms/ios/versions/800000000").
     to_return(status: 200, body: itc_read_fixture_file('app_version.json'), headers: { 'Content-Type' => 'application/json' })
 end
 


### PR DESCRIPTION
PR is ready for review. I did 3 main things:
* updated unit test data to new format
* refactored the `client.app_version` method to allow querying less the server when we already have the data
* replaced the `application.platform` field with a method that tries to find (reused from original `client.app-version` method

I only tested with unit tests so far.

TODO:
* ~~I probably want to rework the `live_version` change and not remove so much. We lack unit test to cover that case~~
* ~~I can squash all that into one commit if we agree we want to keep the refactoring to reduce server calls~~.
