### PR TITLE
Prevent infinite loop inside login retries by decreasing retry counter

### DIFF
--- a/lib/spaceship/client.rb
+++ b/lib/spaceship/client.rb
@@ -201,7 +201,7 @@ module Spaceship
       end
       raise ex # re-raise the exception
     rescue UnauthorizedAccessError => ex
-      if @loggedin
+      if @loggedin && !(tries -= 1).zero?
         msg = "Auth error received: '#{ex.message}'. Login in again then retrying after 3 seconds (remaining: #{tries})..."
         puts msg if $verbose
         logger.warn msg


### PR DESCRIPTION
Addresses #261

Apple sends 401s when a user can login but hasn't proper access rights

Tested with a live account without admin access on developer.apple.com
